### PR TITLE
futex: Add work-around for inconsistent pi_state

### DIFF
--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -2448,6 +2448,16 @@ retry:
 		 * Since we just failed the trylock; there must be an owner.
 		 */
 		newowner = rt_mutex_owner(&pi_state->pi_mutex);
+		WARN_ON(!newowner);
+
+		/*
+		 * pi_state is incorrect, some other task did a lock steal and
+		 * we returned due to timeout or signal without taking the
+		 * rt_mutex. Too late.
+		 */
+		if (!newowner)
+			newowner = rt_mutex_next_owner(&pi_state->pi_mutex);
+
 		BUG_ON(!newowner);
 	} else {
 		WARN_ON_ONCE(argowner != current);


### PR DESCRIPTION
Commit 73d786bd043e ("futex: Rework inconsistent rt_mutex/futex_q
state") removed a work-around in fixup_owner() that fixed an
inconsistent pi_state.

Part of the work-around was added back by commit 1352130fe6aa ("futex:
Avoid violating the 10th rule of futex"). However it left out, for
good reason (it might hide a race), the fix-up for the case where the
rt_mutex ends up w/o an owner.

This commit adds back the fix-up for the pi_state pi_mutex owner to
work around the race that is still present in the kernel. This allows
us to recover and continue if we find an rt_mutex w/o an owner. We
also throw a warning so we can continue the search for the race.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>