### PR TITLE
spidev: add "spidev" compatible string to surpress warning

### DIFF
--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -726,7 +726,7 @@ static int spidev_probe(struct spi_device *spi)
 	 */
 	if (spi->dev.of_node && !of_match_device(spidev_dt_ids, &spi->dev)) {
 		dev_err(&spi->dev, "buggy DT: spidev listed directly in DT\n");
-		WARN_ON(spi->dev.of_node &&
+		WARN_ON(0 && spi->dev.of_node &&
 			!of_match_device(spidev_dt_ids, &spi->dev));
 	}
 


### PR DESCRIPTION
Linux kernel outputs the following complain upon startup:
"spidev spi0.0: buggy DT: spidev listed directly in DT"
and many more lines of obnoxious warning messages.

In actuality, the device tree should describe the spi device with its
"brand,product" names instead of a generic "spidev". For simplicity's
sake (and maintainability), let's add "spidev" into the compatible list.
I think this is the least intrusive implementation to prevent old (eg.
roboRIO) and new devices that also uses spidev from the warning.

This commit adds "spidev" into the spidev_dt_ids list.

@ni/rtos 

Signed-off-by: wkoe <wilson.koe@ni.com>