### PR TITLE
artemis: add artemis into hardware model compatibility list

### DIFF
--- a/arch/arm/boot/dts/ni-7AAE.dts
+++ b/arch/arm/boot/dts/ni-7AAE.dts
@@ -3,7 +3,7 @@
 
 / {
 	model = "NI roboRIO 2.0";
-	compatible = "ni,zynq", "xlnx,zynq-7000";
+	compatible = "ni,zynq", "xlnx,zynq-7000", "ni,artemis";
 
 	aliases {
 		spi0 = &spi0;


### PR DESCRIPTION
As artmemis has a design of combining zynq processor with sd card (ext4)
instead of NAND drive, a unique compatible string can be added to notify
the kernel if the target is artemis via the device tree. This string will
be used as a flag to allow artemis configuration scripts to run (eg.
postint for systemlink installation).

This commit adds "ni,artemis" into the model compatibility list.

@ni/rtos 

Signed-off-by: wkoe <wilson.koe@ni.com>