### PR TITLE
arm: dts: ni-vb: declare partitions in device tree

### DIFF
--- a/arch/arm/boot/dts/ni-vb.dtsi
+++ b/arch/arm/boot/dts/ni-vb.dtsi
@@ -100,6 +100,28 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			partition@0 {
+				label = "fsbl";
+				reg = <0x0 0x20000>;
+				read-only = <1>;
+			};
+
+			partition@1 {
+				label = "u-boot";
+				reg = <0x20000 0x80000>;
+				read-only = <1>;
+			};
+
+			partition@2 {
+				label = "boot-config";
+				reg = <0xA0000 0x2800000>;
+			};
+
+			partition@3 {
+				label = "root";
+				reg = <0x28A0000 0xD760000>;
+			};
 		};
 
 		swdt@f8005000 {


### PR DESCRIPTION
We've been sending NAND partition information from u-boot to the kernel
via cmdline:

   mtdparts=xilinx_nand:128k(fsbl)ro,512k(u-boot)ro,40M(boot-config),-(root)

Shipping versions of the bootloader have a bug that restricts the kernel
cmdline to 256 bytes, so that space is at a premium. There exists a
perfectly good mechanism for declaring partitions via the device tree
instead-- by doing it this way we can free up 74 characters of cmdline
space.

Verified that /proc/mtd lists the same partitions on a VB-8034 before
this change as it does after the change with the `mtdparts` variable
removed from the cmdline.

Signed-off-by: Brandon Streiff <brandon.streiff@ni.com>