### PR TITLE
i2c-i801.c: Skip SPD initialization on cRIO-903x

### DIFF
--- a/drivers/i2c/busses/i2c-i801.c
+++ b/drivers/i2c/busses/i2c-i801.c
@@ -1311,6 +1311,8 @@ static void register_dell_lis3lv02d_i2c_device(struct i801_priv *priv)
 /* Register optional slaves */
 static void i801_probe_optional_slaves(struct i801_priv *priv)
 {
+	const char *product;
+
 	/* Only register slaves on main SMBus channel */
 	if (priv->features & FEATURE_IDF)
 		return;
@@ -1330,11 +1332,17 @@ static void i801_probe_optional_slaves(struct i801_priv *priv)
 	if (is_dell_system_with_lis3lv02d())
 		register_dell_lis3lv02d_i2c_device(priv);
 
-	/* Instantiate SPD EEPROMs unless the SMBus is multiplexed */
+	/* Instantiate SPD EEPROMs unless the SMBus is multiplexed or it's a cRIO-903x */
+	product = dmi_get_system_info(DMI_PRODUCT_NAME);
+	if(strncmp(product, "NI cRIO-903", 11)) {
 #if IS_ENABLED(CONFIG_I2C_MUX_GPIO)
-	if (!priv->mux_drvdata)
+		if (!priv->mux_drvdata)
 #endif
-		i2c_register_spd(&priv->adapter);
+			i2c_register_spd(&priv->adapter);
+	}
+	else {
+		dev_info(&priv->adapter.dev, "Found %s, skipping SPD registration.", product);
+	}
 }
 #else
 static void __init input_apanel_init(void) {}


### PR DESCRIPTION
The cRIO-903x architecture is sort of special, we do not connect
a dimm to the SPD because we use flash instead, but the SPD is still
present because the processor expects it.  However, enumerating and
registering the SPD i2c bus is causing interrupt storms, so for now
we skip the registration on all 903x devices.

Fixes: 01590f361e94 ("i2c: i801: Instantiate SPD EEPROMs automatically")
Signed-off-by: Bill Pittman <bill.pittman@ni.com>
Natinst-AZDO-ID: 1573148