### PR TITLE
buildnipkg: adding roboRIO 2.0 boot command

### DIFF
--- a/scripts/package/buildnipkg
+++ b/scripts/package/buildnipkg
@@ -135,7 +135,12 @@ EOF
 
 		sed -i "s/populate-device-codes/`echo ${TARGET_DEVCODES} | sed 's/[ \t]*\([^ \t]*\)/0x\1 /g' | sed 's/[ \t]*$//'`/" ${bootdir}/linux.its
 		cat <<EOF > ${bootdir}/bootscript.txt
-setenv set_args 'setenv bootargs \${consoleparam} \$mtdparts ubi.mtd=boot-config ubi.mtd=root root=ubi1:rootfs rw rootfstype=ubifs kthreadd_pri=25 ksoftirqd_pri=8 irqthread_pri=15 \${usb_gadget_args} \$othbootargs'
+
+if test \${DeviceCode} -eq 0x7AAE; then
+  setenv set_args 'setenv bootargs \${consoleparam} root=/dev/mmcblk0p3 rw \${usb_gadget_args} rcu_nocbs=all rootdelay=1 \$othbootargs'
+else
+  setenv set_args 'setenv bootargs \${consoleparam} \$mtdparts ubi.mtd=boot-config ubi.mtd=root root=ubi1:rootfs rw rootfstype=ubifs kthreadd_pri=25 ksoftirqd_pri=8 irqthread_pri=15 \${usb_gadget_args} \$othbootargs'
+fi
 
 # cRIO-9068 doesn't have USB gadget, so skip it on that device
 if test \${DeviceCode} != 0x76D6; then


### PR DESCRIPTION
roborio2 using SD card as storage device and use ext4 file system
it is different from previous product that use ubifs.
in this case, a different boot command should be use for roboRIO 2.0

Signed-off-by: Kim Khiam Lim <kim.khiam.lim@ni.com>