### PR TITLE
Revert some upstream commits to get USB gadget working

### DIFF
--- a/drivers/usb/dwc3/dwc3-pci.c
+++ b/drivers/usb/dwc3/dwc3-pci.c
@@ -348,10 +348,8 @@ err:
 static void dwc3_pci_remove(struct pci_dev *pci)
 {
 	struct dwc3_pci		*dwc = pci_get_drvdata(pci);
-	struct pci_dev		*pdev = dwc->pci;
 
-	if (pdev->device == PCI_DEVICE_ID_INTEL_BYT)
-		gpiod_remove_lookup_table(&platform_bytcr_gpios);
+	gpiod_remove_lookup_table(&platform_bytcr_gpios);
 #ifdef CONFIG_PM
 	cancel_work_sync(&dwc->wakeup_work);
 #endif

--- a/drivers/usb/dwc3/dwc3-pci.c
+++ b/drivers/usb/dwc3/dwc3-pci.c
@@ -16,7 +16,6 @@
 #include <linux/pm_runtime.h>
 #include <linux/platform_device.h>
 #include <linux/gpio/consumer.h>
-#include <linux/gpio/machine.h>
 #include <linux/acpi.h>
 #include <linux/delay.h>
 
@@ -83,15 +82,6 @@ static const struct acpi_gpio_mapping acpi_dwc3_byt_gpios[] = {
 	{ "reset-gpios", &reset_gpios, 1 },
 	{ "cs-gpios", &cs_gpios, 1 },
 	{ },
-};
-
-static struct gpiod_lookup_table platform_bytcr_gpios = {
-	.dev_id		= "0000:00:16.0",
-	.table		= {
-		GPIO_LOOKUP("INT33FC:00", 54, "cs", GPIO_ACTIVE_HIGH),
-		GPIO_LOOKUP("INT33FC:02", 14, "reset", GPIO_ACTIVE_HIGH),
-		{}
-	},
 };
 
 static int dwc3_byt_enable_ulpi_refclock(struct pci_dev *pci)
@@ -226,13 +216,6 @@ static int dwc3_pci_quirks(struct dwc3_pci *dwc,
 				dev_dbg(&pdev->dev, "failed to add mapping table\n");
 
 			/*
-			 * A lot of BYT devices lack ACPI resource entries for
-			 * the GPIOs, add a fallback mapping to the reference
-			 * design GPIOs which all boards seem to use.
-			 */
-			gpiod_add_lookup_table(&platform_bytcr_gpios);
-
-			/*
 			 * These GPIOs will turn on the USB2 PHY. Note that we have to
 			 * put the gpio descriptors again here because the phy driver
 			 * might want to grab them, too.
@@ -349,7 +332,6 @@ static void dwc3_pci_remove(struct pci_dev *pci)
 {
 	struct dwc3_pci		*dwc = pci_get_drvdata(pci);
 
-	gpiod_remove_lookup_table(&platform_bytcr_gpios);
 #ifdef CONFIG_PM
 	cancel_work_sync(&dwc->wakeup_work);
 #endif


### PR DESCRIPTION
Reverting two upstream commits because the assumption that
any baytrail hardware without ACPI entries for USB PHY "reset" and
"cs" will have GPIO controller INT33FC in their ACPI tables - which
is not the case for some of our targets.

### Testing
With these reverts, `usb0` interface appears in cRIO-9030, cRIO-9053, cRIO-9037, cRIO-9043, cRIO-9049.