### PR TITLE
scripts/dtc: Remove redundant YYLOC in dtc-lexer.lex.c_shipped

### DIFF
--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -631,7 +631,6 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
Required to fix up the cherry-pick [1] since in 4.14 version of the kernel, flex and bison were not supported in the kernel build, so their output was included in the source tree. In 4.17, the build was changed [2] to build directly from the source .' file. By the time this fix [3] was added in 5.6, the c_shipped files were long gone, so the patch didn't fic them as well.

[1] 3efeb66ba64a - scripts/dtc: Remove redundant YYLOC global declaration
[2] e039139be8c2 - scripts/dtc: generate lexer and parser during build instead of shipping
[3] e33a814e772c - scripts/dtc: Remove redundant YYLOC global declaration

Upstream-status: N/A - only relevant to the backport
Signed-off-by: Joe Hershberger <joe.hershberger@ni.com>