### PR TITLE
[6.0] Revert "e1000e: Add delays after writing to registers"

### DIFF
--- a/drivers/net/ethernet/intel/Kconfig
+++ b/drivers/net/ethernet/intel/Kconfig
@@ -84,15 +84,6 @@ config E1000E_HWTS
 	 devices. The cross-timestamp is available through the PTP clock
 	 driver precise cross-timestamp ioctl (PTP_SYS_OFFSET_PRECISE).
 
-config E1000_DELAY
-	bool "Add delays to e1000x drivers"
-	default n
-	depends on (E1000E || E1000) && PREEMPT_RT
-	help
-	  Enable delays after large numbers of MMIO writes to registers.
-	  The delays aid in preventing noticeable impact on real-time
-	  performance when a connection is interrupted.
-
 config IGB
 	tristate "Intel(R) 82575/82576 PCI-Express Gigabit Ethernet support"
 	depends on PCI

--- a/drivers/net/ethernet/intel/e1000/e1000.h
+++ b/drivers/net/ethernet/intel/e1000/e1000.h
@@ -199,13 +199,6 @@ struct e1000_rx_ring {
 #define E1000_TX_DESC(R, i)		E1000_GET_DESC(R, i, e1000_tx_desc)
 #define E1000_CONTEXT_DESC(R, i)	E1000_GET_DESC(R, i, e1000_context_desc)
 
-/* Time to wait after writing large amount of data to registers */
-#ifdef CONFIG_E1000_DELAY
-#define E1000_WR_DELAY()                usleep_range(50, 100)
-#else
-#define E1000_WR_DELAY()
-#endif
-
 /* board specific private data structure */
 
 struct e1000_adapter {

--- a/drivers/net/ethernet/intel/e1000/e1000_main.c
+++ b/drivers/net/ethernet/intel/e1000/e1000_main.c
@@ -2159,7 +2159,6 @@ static void e1000_enter_82542_rst(struct e1000_adapter *adapter)
 	rctl = er32(RCTL);
 	rctl |= E1000_RCTL_RST;
 	ew32(RCTL, rctl);
-	E1000_WR_DELAY();
 	E1000_WRITE_FLUSH();
 	mdelay(5);
 
@@ -2176,7 +2175,6 @@ static void e1000_leave_82542_rst(struct e1000_adapter *adapter)
 	rctl = er32(RCTL);
 	rctl &= ~E1000_RCTL_RST;
 	ew32(RCTL, rctl);
-	E1000_WR_DELAY();
 	E1000_WRITE_FLUSH();
 	mdelay(5);
 
@@ -2325,9 +2323,6 @@ static void e1000_set_rx_mode(struct net_device *netdev)
 		 */
 		E1000_WRITE_REG_ARRAY(hw, MTA, i, mcarray[i]);
 	}
-
-	E1000_WR_DELAY();
-
 	E1000_WRITE_FLUSH();
 
 	if (hw->mac_type == e1000_82542_rev2_0)

--- a/drivers/net/ethernet/intel/e1000e/82571.c
+++ b/drivers/net/ethernet/intel/e1000e/82571.c
@@ -494,8 +494,6 @@ static void e1000_put_hw_semaphore_82571(struct e1000_hw *hw)
 {
 	u32 swsm;
 
-	E1000_WR_DELAY();
-
 	swsm = er32(SWSM);
 	swsm &= ~(E1000_SWSM_SMBI | E1000_SWSM_SWESMBI);
 	ew32(SWSM, swsm);
@@ -547,7 +545,6 @@ static void e1000_put_hw_semaphore_82573(struct e1000_hw *hw)
 {
 	u32 extcnf_ctrl;
 
-	E1000_WR_DELAY();
 	extcnf_ctrl = er32(EXTCNF_CTRL);
 	extcnf_ctrl &= ~E1000_EXTCNF_CTRL_MDIO_SW_OWNERSHIP;
 	ew32(EXTCNF_CTRL, extcnf_ctrl);
@@ -1098,8 +1095,6 @@ static s32 e1000_init_hw_82571(struct e1000_hw *hw)
 	e_dbg("Zeroing the MTA\n");
 	for (i = 0; i < mac->mta_reg_count; i++)
 		E1000_WRITE_REG_ARRAY(hw, E1000_MTA, i, 0);
-
-	E1000_WR_DELAY();
 
 	/* Setup link and flow control */
 	ret_val = mac->ops.setup_link(hw);

--- a/drivers/net/ethernet/intel/e1000e/e1000.h
+++ b/drivers/net/ethernet/intel/e1000e/e1000.h
@@ -71,13 +71,6 @@ struct e1000_info;
 /* Time to wait before putting the device into D3 if there's no link (in ms). */
 #define LINK_TIMEOUT		100
 
-/* Time to wait after writing large amount of data to registers */
-#ifdef CONFIG_E1000_DELAY
-#define E1000_WR_DELAY()		usleep_range(50, 100)
-#else
-#define E1000_WR_DELAY()
-#endif
-
 /* Count for polling __E1000_RESET condition every 10-20msec.
  * Experimentation has shown the reset can take approximately 210msec.
  */

--- a/drivers/net/ethernet/intel/e1000e/mac.c
+++ b/drivers/net/ethernet/intel/e1000e/mac.c
@@ -335,7 +335,6 @@ void e1000e_update_mc_addr_list_generic(struct e1000_hw *hw,
 	/* replace the entire MTA table */
 	for (i = hw->mac.mta_reg_count - 1; i >= 0; i--)
 		E1000_WRITE_REG_ARRAY(hw, E1000_MTA, i, hw->mac.mta_shadow[i]);
-	E1000_WR_DELAY();
 	e1e_flush();
 }
 

--- a/drivers/net/ethernet/intel/e1000e/netdev.c
+++ b/drivers/net/ethernet/intel/e1000e/netdev.c
@@ -2943,7 +2943,6 @@ static void e1000_configure_tx(struct e1000_adapter *adapter)
 		e1000e_update_tdt_wa(tx_ring, 0);
 	else
 		writel(0, tx_ring->tail);
-	E1000_WR_DELAY();
 
 	/* Set the Tx Interrupt Delay register */
 	ew32(TIDV, adapter->tx_int_delay);
@@ -3221,7 +3220,6 @@ static void e1000_configure_rx(struct e1000_adapter *adapter)
 	rctl = er32(RCTL);
 	if (!(adapter->flags2 & FLAG2_NO_DISABLE_RX))
 		ew32(RCTL, rctl & ~E1000_RCTL_EN);
-	E1000_WR_DELAY();
 	e1e_flush();
 	usleep_range(10000, 11000);
 
@@ -3251,7 +3249,6 @@ static void e1000_configure_rx(struct e1000_adapter *adapter)
 	ctrl_ext |= E1000_CTRL_EXT_IAME;
 	ew32(IAM, 0xffffffff);
 	ew32(CTRL_EXT, ctrl_ext);
-	E1000_WR_DELAY();
 	e1e_flush();
 
 	/* Setup the HW Rx Head and Tail Descriptor Pointers and
@@ -3271,7 +3268,6 @@ static void e1000_configure_rx(struct e1000_adapter *adapter)
 		e1000e_update_rdt_wa(rx_ring, 0);
 	else
 		writel(0, rx_ring->tail);
-	E1000_WR_DELAY();
 
 	/* Enable Receive Checksum Offload for TCP and UDP */
 	rxcsum = er32(RXCSUM);
@@ -3397,7 +3393,6 @@ static int e1000e_write_uc_addr_list(struct net_device *netdev)
 		ew32(RAH(rar_entries), 0);
 		ew32(RAL(rar_entries), 0);
 	}
-	E1000_WR_DELAY();
 	e1e_flush();
 
 	return count;
@@ -3473,12 +3468,10 @@ static void e1000e_setup_rss_hash(struct e1000_adapter *adapter)
 	netdev_rss_key_fill(rss_key, sizeof(rss_key));
 	for (i = 0; i < 10; i++)
 		ew32(RSSRK(i), rss_key[i]);
-	E1000_WR_DELAY();
 
 	/* Direct all traffic to queue 0 */
 	for (i = 0; i < 32; i++)
 		ew32(RETA(i), 0);
-	E1000_WR_DELAY();
 
 	/* Disable raw packet checksumming so that RSS hash is placed in
 	 * descriptor on writeback.


### PR DESCRIPTION
This reverts commit 2f740513bbec0b97bbd7520e7aa82fc563602e1e.

The custom delay patch for the E1000 driver no longer appears necessary based on hand-testing.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

## Note to reviewers:
The E1000_DELAY config option has never been enabled in the 6.0 kernel branch.

## Testing:
Built locally. 