### PR TITLE
[6.0] 8250: make disabling CONFIG_SERIAL_8250_NI16550 work correctly

### DIFF
--- a/drivers/acpi/acpi_pnp.c
+++ b/drivers/acpi/acpi_pnp.c
@@ -218,10 +218,12 @@ static const struct acpi_device_id acpi_pnp_device_ids[] = {
 	{"MVX00A1"},		/*  Deskline K56 Phone System PnP */
 	{"MVX00F2"},		/* PC Rider K56 Phone System PnP */
 	{"nEC8241"},		/* NEC 98NOTE SPEAKER PHONE FAX MODEM(33600bps) */
+#ifdef CONFIG_SERIAL_8250_NI16550
 	{"NIC7750"},		/* National Instruments (NI) 16550 PNP */
 	{"NIC7772"},		/* National Instruments (NI) 16550 PNP */
 	{"NIC792B"},		/* National Instruments (NI) 16550 PNP */
 	{"NIC7A69"},		/* National Instruments (NI) 16550 PNP */
+#endif
 	{"PMC2430"},		/* Pace 56 Voice Internal Plug & Play Modem */
 	{"PNP0500"},		/* Generic standard PC COM port     */
 	{"PNP0501"},		/* Generic 16550A-compatible COM port */

--- a/drivers/tty/serial/8250/8250_pnp.c
+++ b/drivers/tty/serial/8250/8250_pnp.c
@@ -211,11 +211,13 @@ static const struct pnp_device_id pnp_dev_table[] = {
 	{	"MVX00A1",		0	},
 	/* PC Rider K56 Phone System PnP */
 	{	"MVX00F2",		0	},
+#ifdef CONFIG_SERIAL_8250_NI16550
 	/* National Instruments (NI) 16550 PNP */
 	{	"NIC7750",	NI_CLK_33333333			},
 	{	"NIC7772",	NI_CAP_PMR | NI_16BYTE_FIFO	},
 	{	"NIC792B",	NI_CPR_CLK_25000000		},
 	{	"NIC7A69",	NI_CPR_CLK_33333333		},
+#endif
 	/* NEC 98NOTE SPEAKER PHONE FAX MODEM(33600bps) */
 	{	"nEC8241",		0	},
 	/* Pace 56 Voice Internal Plug & Play Modem */


### PR DESCRIPTION
The legacy PNP IDs for NI 16550 devices (which is how 8250_pnp enumerates them) are not gated by CONFIG_SERIAL_8250_NI16550, so if you turn that option off, you end up with NI 16550s in an unfortunate partially-enumerated state because 8250_pnp finds them, but doesn't initialize them properly.

This change puts those IDs behind ifdefs so that it becomes possible to disable the existing NI 16550 driver.