### PR TITLE
pps: Use sysfs module parameter to replace PPS_MAX_SOURCES.

### DIFF
--- a/drivers/pps/pps.c
+++ b/drivers/pps/pps.c
@@ -354,7 +354,7 @@ int pps_register_cdev(struct pps_device *pps)
 	 * Get new ID for the new PPS source.  After idr_alloc() calling
 	 * the new source will be freely available into the kernel.
 	 */
-	err = idr_alloc(&pps_idr, pps, 0, PPS_MAX_SOURCES, GFP_KERNEL);
+	err = idr_alloc(&pps_idr, pps, 0, pps_max_sources, GFP_KERNEL);
 	if (err < 0) {
 		if (err == -ENOSPC) {
 			pr_err("%s: too many PPS sources in the system\n",
@@ -449,7 +449,7 @@ EXPORT_SYMBOL(pps_lookup_dev);
 static void __exit pps_exit(void)
 {
 	class_destroy(pps_class);
-	unregister_chrdev_region(pps_devt, PPS_MAX_SOURCES);
+	unregister_chrdev_region(pps_devt, pps_max_sources);
 }
 
 static int __init pps_init(void)
@@ -463,7 +463,7 @@ static int __init pps_init(void)
 	}
 	pps_class->dev_groups = pps_groups;
 
-	err = alloc_chrdev_region(&pps_devt, 0, PPS_MAX_SOURCES, "pps");
+	err = alloc_chrdev_region(&pps_devt, 0, pps_max_sources, "pps");
 	if (err < 0) {
 		pr_err("failed to allocate char device region\n");
 		goto remove_class;

--- a/drivers/pps/sysfs.c
+++ b/drivers/pps/sysfs.c
@@ -8,6 +8,7 @@
 
 #include <linux/device.h>
 #include <linux/module.h>
+#include <linux/moduleparam.h>
 #include <linux/string.h>
 #include <linux/pps_kernel.h>
 
@@ -97,3 +98,12 @@ const struct attribute_group *pps_groups[] = {
 	&pps_group,
 	NULL,
 };
+
+/*
+ * Module parameters
+ */
+
+unsigned int pps_max_sources = 16;
+
+MODULE_PARM_DESC(pps_max_sources, "Maximum number of pps sources that can be allocated.");
+module_param(pps_max_sources, uint, 0664);

--- a/include/linux/pps_kernel.h
+++ b/include/linux/pps_kernel.h
@@ -67,6 +67,7 @@ struct pps_device {
  */
 
 extern const struct attribute_group *pps_groups[];
+extern unsigned int pps_max_sources;
 
 /*
  * Internal functions.

--- a/include/uapi/linux/pps.h
+++ b/include/uapi/linux/pps.h
@@ -26,7 +26,7 @@
 #include <linux/types.h>
 
 #define PPS_VERSION		"5.3.6"
-#define PPS_MAX_SOURCES		16		/* should be enough... */
+#define PPS_MAX_SOURCES		16		/* deprecated, use sysfs instead */
 
 /* Implementation note: the logical states ``assert'' and ``clear''
  * are implemented in terms of the chip register, i.e. ``assert''


### PR DESCRIPTION
Currently, the PPS_MAX_SOURCES is a hard coded constant. On some systems, the current maximum of 16 is too low. This change converts that logic to use a sysfs parameter instead of a hard-coded value and increases the default value to 32.

## Testing:
- Built and installed new kernel on target. 
   - Confirmed that new `/sysfs/module/pps_core/paramters/pps_max_sources` existed and was set to default of 32. 
   - Confirmed value could be changed.
   - Confirmed invalid values errored.
   - Confirmed that adding `pps_core.pps_max_sources=64` to the boot parameters resulted in a value of 64.
- Ran `checkpatch.pl`