### PR TITLE
pps: Increase PPS_MAX_SOURCES value.

### DIFF
--- a/include/uapi/linux/pps.h
+++ b/include/uapi/linux/pps.h
@@ -25,8 +25,8 @@
 
 #include <linux/types.h>
 
-#define PPS_VERSION		"5.3.6"
-#define PPS_MAX_SOURCES		16		/* should be enough... */
+#define PPS_VERSION			"5.3.6"
+#define PPS_MAX_SOURCES		MINORMASK
 
 /* Implementation note: the logical states ``assert'' and ``clear''
  * are implemented in terms of the chip register, i.e. ``assert''


### PR DESCRIPTION
For consistency with what ptp uses for minors, this change sets PPS_MAX_SOURCES to MINORMASK + 1.

The PPS_MAX_SOURCES value is currently set to 16. In some cases this was not sufficient for a system. For example, a system with multiple 4+ PCIe cards each with 4 PTP-capable ethernet interfaces could run out of the available PPS major:minors if each interface registers a PPS source.

**Note:** Alternate approach for #118 

## Testing:
- Ran checkpatch.pl, no issues.
- Built locally and confirmed it built without errors.