### PR TITLE
Revert "Revert "mmc: core: enable CMD19 tuning for DDR50 mode""

### DIFF
--- a/drivers/mmc/core/sd.c
+++ b/drivers/mmc/core/sd.c
@@ -665,9 +665,25 @@ static int mmc_sd_init_uhs_card(struct mmc_card *card)
 	 * SDR104 mode SD-cards. Note that tuning is mandatory for SDR104.
 	 */
 	if (!mmc_host_is_spi(card->host) &&
-	    (card->sd_bus_speed == UHS_SDR50_BUS_SPEED ||
-	     card->sd_bus_speed == UHS_SDR104_BUS_SPEED))
+		(card->host->ios.timing == MMC_TIMING_UHS_SDR50 ||
+		 card->host->ios.timing == MMC_TIMING_UHS_DDR50 ||
+		 card->host->ios.timing == MMC_TIMING_UHS_SDR104)) {
 		err = mmc_execute_tuning(card);
+
+		/*
+		 * As SD Specifications Part1 Physical Layer Specification
+		 * Version 3.01 says, CMD19 tuning is available for unlocked
+		 * cards in transfer state of 1.8V signaling mode. The small
+		 * difference between v3.00 and 3.01 spec means that CMD19
+		 * tuning is also available for DDR50 mode.
+		 */
+		if (err && card->host->ios.timing == MMC_TIMING_UHS_DDR50) {
+			pr_warn("%s: ddr50 tuning failed\n",
+				mmc_hostname(card->host));
+			err = 0;
+		}
+	}
+
 out:
 	kfree(status);
 


### PR DESCRIPTION
This reverts commit 43ccc9ea05d44f59fc231f5fc16acebb07017be7 which is no longer necessary as CMD19 tuning works for DDR50 mode in 6.1 kernels.

WI: [2113488](https://dev.azure.com/ni/DevCentral/_workitems/edit/2113488)

### Testing
- [x] With swissbit 16G micro sd card oon a cRIO-9053, no "ddr50 tuning failed" log in dmesg
- [x] Added logs to mmc code to verify that tuning is happening and not being skipped.
- [x] Following log in dmesg confirming DDR50
         `mmc0: new ultra high speed DDR50 SDHC card at address 0001`
- [x] Read speeds from the micro sd card in 43MB/s range which indicate DDR50 mode (and not high speed mode which is limited to 35MB/s)
- [x] Reproduced issue on the target on older kernel before the mmc patches were put in.