### PR TITLE
[6.1] Revert now unneeded mmc quirks2

### DIFF
--- a/drivers/mmc/host/sdhci-pci-core.c
+++ b/drivers/mmc/host/sdhci-pci-core.c
@@ -1132,10 +1132,6 @@ static int byt_sd_probe_slot(struct sdhci_pci_slot *slot)
 	    slot->chip->pdev->subsystem_device == PCI_SUBDEVICE_ID_NI_78E3)
 		slot->host->mmc->caps2 |= MMC_CAP2_AVOID_3_3V;
 
-	if (slot->chip->pdev->device == PCI_DEVICE_ID_INTEL_BYT_SD)
-		slot->host->quirks2 |= SDHCI_QUIRK2_NEED_DELAY_AFTER_CLK_DISABLE |
-				       SDHCI_QUIRK2_SPURIOUS_CARD_INSERT_INTERRUPT;
-
 	byt_needs_pwr_off(slot);
 
 	return 0;

--- a/drivers/mmc/host/sdhci.c
+++ b/drivers/mmc/host/sdhci.c
@@ -2056,12 +2056,6 @@ void sdhci_set_clock(struct sdhci_host *host, unsigned int clock)
 		sdhci_writew(host, clk & ~SDHCI_CLOCK_CARD_EN,
 			SDHCI_CLOCK_CONTROL);
 
-	if (host->quirks2 & SDHCI_QUIRK2_NEED_DELAY_AFTER_CLK_DISABLE) {
-		spin_unlock_irq(&host->lock);
-		usleep_range(900, 1100);
-		spin_lock_irq(&host->lock);
-	}
-
 	if (clock == 0) {
 		sdhci_writew(host, 0, SDHCI_CLOCK_CONTROL);
 		return;

--- a/drivers/mmc/host/sdhci.c
+++ b/drivers/mmc/host/sdhci.c
@@ -2064,17 +2064,11 @@ void sdhci_set_clock(struct sdhci_host *host, unsigned int clock)
 
 	if (clock == 0) {
 		sdhci_writew(host, 0, SDHCI_CLOCK_CONTROL);
-		goto out_delay;
+		return;
 	}
 
 	clk = sdhci_calc_clk(host, clock, &host->mmc->actual_clock);
 	sdhci_enable_clk(host, clk);
-out_delay:
-	if (host->quirks2 & SDHCI_QUIRK2_SPURIOUS_CARD_INSERT_INTERRUPT) {
-		spin_unlock_irq(&host->lock);
-		usleep_range(4900, 5100);
-		spin_lock_irq(&host->lock);
-	}
 }
 EXPORT_SYMBOL_GPL(sdhci_set_clock);
 

--- a/drivers/mmc/host/sdhci.c
+++ b/drivers/mmc/host/sdhci.c
@@ -2056,8 +2056,11 @@ void sdhci_set_clock(struct sdhci_host *host, unsigned int clock)
 		sdhci_writew(host, clk & ~SDHCI_CLOCK_CARD_EN,
 			SDHCI_CLOCK_CONTROL);
 
-	if (host->quirks2 & SDHCI_QUIRK2_NEED_DELAY_AFTER_CLK_DISABLE)
-		mdelay(1);
+	if (host->quirks2 & SDHCI_QUIRK2_NEED_DELAY_AFTER_CLK_DISABLE) {
+		spin_unlock_irq(&host->lock);
+		usleep_range(900, 1100);
+		spin_lock_irq(&host->lock);
+	}
 
 	if (clock == 0) {
 		sdhci_writew(host, 0, SDHCI_CLOCK_CONTROL);
@@ -2067,8 +2070,11 @@ void sdhci_set_clock(struct sdhci_host *host, unsigned int clock)
 	clk = sdhci_calc_clk(host, clock, &host->mmc->actual_clock);
 	sdhci_enable_clk(host, clk);
 out_delay:
-	if (host->quirks2 & SDHCI_QUIRK2_SPURIOUS_CARD_INSERT_INTERRUPT)
-		mdelay(5);
+	if (host->quirks2 & SDHCI_QUIRK2_SPURIOUS_CARD_INSERT_INTERRUPT) {
+		spin_unlock_irq(&host->lock);
+		usleep_range(4900, 5100);
+		spin_lock_irq(&host->lock);
+	}
 }
 EXPORT_SYMBOL_GPL(sdhci_set_clock);
 

--- a/drivers/mmc/host/sdhci.h
+++ b/drivers/mmc/host/sdhci.h
@@ -481,8 +481,6 @@ struct sdhci_host {
 #define SDHCI_QUIRK2_USE_32BIT_BLK_CNT			(1<<18)
 /* Issue CMD and DATA reset together */
 #define SDHCI_QUIRK2_ISSUE_CMD_DAT_RESET_TOGETHER	(1<<19)
-/* Controller requires delay between card clock disable and param change */
-#define SDHCI_QUIRK2_NEED_DELAY_AFTER_CLK_DISABLE	(1<<19)
 
 	int irq;		/* Device IRQ */
 	void __iomem *ioaddr;	/* Mapped address */

--- a/drivers/mmc/host/sdhci.h
+++ b/drivers/mmc/host/sdhci.h
@@ -482,9 +482,7 @@ struct sdhci_host {
 /* Issue CMD and DATA reset together */
 #define SDHCI_QUIRK2_ISSUE_CMD_DAT_RESET_TOGETHER	(1<<19)
 /* Controller requires delay between card clock disable and param change */
-#define SDHCI_QUIRK2_NEED_DELAY_AFTER_CLK_DISABLE	(1<<20)
-/* Controller may interrupt multiple times for card insert */
-#define SDHCI_QUIRK2_SPURIOUS_CARD_INSERT_INTERRUPT	(1<<21)
+#define SDHCI_QUIRK2_NEED_DELAY_AFTER_CLK_DISABLE	(1<<19)
 
 	int irq;		/* Device IRQ */
 	void __iomem *ioaddr;	/* Mapped address */


### PR DESCRIPTION
This change reverts the following:

- [2e2158ac8d6b](https://github.com/ni/linux/commit/2e2158ac8d6b) mmc: sdhci: Add quirk for delay between clock disable and param change
- [90c6dfca41d1](https://github.com/ni/linux/commit/90c6dfca41d1) mmc: sdhci: Add quirk work around double rescan
- [c0b3c828958c](https://github.com/ni/linux/commit/c0b3c828958c) mmc: sdhci-pci: Use two delay quirks for Baytrail SD
- [4c41c0d69984](https://github.com/ni/linux/commit/4c41c0d69984) mmc: sdhci: Do not disable interrupts in sdhci_set_clock

[AB#2316626](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2316626)

# Testing:
After testing manually with these reverts, I was unable to reproduce the original bugs. 
