### PR TITLE
serial: 8250: properly set mctrl for prescaler

### DIFF
--- a/drivers/tty/serial/8250/8250_ni.c
+++ b/drivers/tty/serial/8250/8250_ni.c
@@ -268,8 +268,9 @@ static u8 ni16550_read_fifo_size(struct uart_8250_port *uart, int reg)
 
 static void ni16550_set_mctrl(struct uart_port *port, unsigned int mctrl)
 {
-	mctrl |= UART_MCR_CLKSEL;
+	struct uart_8250_port *up = up_to_u8250p(port);
 
+	up->mcr |= UART_MCR_CLKSEL;
 	serial8250_do_set_mctrl(port, mctrl);
 }
 


### PR DESCRIPTION
The set_mctrl callback should be setting struct uart_port::mcr, not just adding UART_MCR_CLKSEL to the local value.

Found by @sjasonsmith. Fixes [AB#2489739](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2489739).