### PR TITLE
include/uapi pps.h: increase PPS_MAX_SOURCES value

### DIFF
--- a/include/uapi/linux/pps.h
+++ b/include/uapi/linux/pps.h
@@ -26,7 +26,7 @@
 #include <linux/types.h>
 
 #define PPS_VERSION		"5.3.6"
-#define PPS_MAX_SOURCES		16		/* should be enough... */
+#define PPS_MAX_SOURCES		MINORMASK
 
 /* Implementation note: the logical states ``assert'' and ``clear''
  * are implemented in terms of the chip register, i.e. ``assert''


### PR DESCRIPTION
For consistency with what others use for minors, this change sets PPS_MAX_SOURCES to MINORMASK.

The PPS_MAX_SOURCES value is currently set to 16. In some cases this was not sufficient for a system. For example, a system with multiple (4+) PCIe cards each with 4 PTP-capable ethernet interfaces could run out of the available PPS major:minors if each interface registers a PPS source.

Acked-by: Rodolfo Giometti <giometti@enneenne.com>

[AB#2400699](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2400699)

## Note to Reviewers:
This patch is submitted to upstream in [this ](https://lore.kernel.org/all/9bac379c-c482-e52b-f7bb-33ed4ef49b40@ni.com/T/#m8723791c82cb0c429216d6fdb4c3fcf2bc952b8e)discussion. In the interest of preventing the problem from continuing while waiting on upstream, I'm submitting the patch and creating a separate work item to track the upstream discussion.