### PR TITLE
Revert "usb: dwc3: gadget: Add 1ms delay after end transfer command without IOC"

### DIFF
--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -1690,7 +1690,6 @@ static int __dwc3_gadget_get_frame(struct dwc3 *dwc)
  */
 static int __dwc3_stop_active_transfer(struct dwc3_ep *dep, bool force, bool interrupt)
 {
-	struct dwc3 *dwc = dep->dwc;
 	struct dwc3_gadget_ep_cmd_params params;
 	u32 cmd;
 	int ret;
@@ -1714,13 +1713,10 @@ static int __dwc3_stop_active_transfer(struct dwc3_ep *dep, bool force, bool int
 	WARN_ON_ONCE(ret);
 	dep->resource_index = 0;
 
-	if (!interrupt) {
-		if (!DWC3_IP_IS(DWC3) || DWC3_VER_IS_PRIOR(DWC3, 310A))
-			mdelay(1);
+	if (!interrupt)
 		dep->flags &= ~DWC3_EP_TRANSFER_STARTED;
-	} else if (!ret) {
+	else if (!ret)
 		dep->flags |= DWC3_EP_END_TRANSFER_PENDING;
-	}
 
 	dep->flags &= ~DWC3_EP_DELAY_STOP;
 	return ret;
@@ -3793,11 +3789,7 @@ void dwc3_stop_active_transfer(struct dwc3_ep *dep, bool force,
 	 * enabled, the EndTransfer command will have completed upon
 	 * returning from this function.
 	 *
-	 * This mode is NOT available on the DWC_usb31 IP.  In this
-	 * case, if the IOC bit is not set, then delay by 1ms
-	 * after issuing the EndTransfer command.  This allows for the
-	 * controller to handle the command completely before DWC3
-	 * remove requests attempts to unmap USB request buffers.
+	 * This mode is NOT available on the DWC_usb31 IP.
 	 */
 
 	__dwc3_stop_active_transfer(dep, force, interrupt);


### PR DESCRIPTION
This reverts commit 1450c82a16bba232dca0ff667b17c0970ddecb85.

That commit caused usblan to not work reliably between some cRIOs (903x,
9041) and windows host.
The issue happens only sometimes and when it happens, windows host would
report the network adapter as unconnected. The only way to reliably
recover from this was to reconnect usb cable or disable and enable
windows network adapter. Rebooting the cRIO would also sometimes fix the
issue.

Natinst-AzDo-ID: [2419039](https://dev.azure.com/ni/DevCentral/_workitems/edit/2419039)

### Testing
- [x] Verified on cRIO-9034 that USBLAN works with the commit reverted.
- [x] Verified on cRIO-9041 that USBLAN works with the commit reverted.

### Note
I intend to create a tech debt item to fix the original commit (if possible) and upstream it.