### PR TITLE
usb: dwc3: call _DSM for core soft reset

### DIFF
--- a/drivers/usb/dwc3/core.c
+++ b/drivers/usb/dwc3/core.c
@@ -266,6 +266,38 @@ u32 dwc3_core_fifo_space(struct dwc3_ep *dep, u8 type)
 }
 
 /**
+ * WORKAROUND: We let BIOS issues the core soft reset to Device
+ * controller for Intel Apollo Lake, via _DSM method.
+ *
+ * The issue is, if core soft reset is issued while Intel Apollo Lake
+ * USB mux is in Host role mode, it takes close to 7 minutes before
+ * we are able to switch USB mux from Host mode to Device mode.
+ */
+static int dwc3_pci_dsm_soft_reset(struct device *dev)
+{
+	int			ret = -ETIMEDOUT;
+	union acpi_object	*obj;
+	guid_t			guid;
+
+	WARN_ON(guid_parse("732b85d5-b7a7-4a1b-9ba0-4bbd00ffd511", &guid));
+
+	obj = acpi_evaluate_dsm(ACPI_HANDLE(dev),
+				&guid,
+				1, 6, NULL);
+	if (!obj) {
+		dev_err(dev, "failed to evaluate _DSM\n");
+		return -EIO;
+	}
+
+	if (obj->type == ACPI_TYPE_INTEGER)
+		ret = (obj->integer.value == 0) ? 0 : -ETIMEDOUT;
+	dev_dbg(dev, "dwc3_pci_dsm_soft_reset() ret= %d\n", ret);
+
+	ACPI_FREE(obj);
+	return ret;
+}
+
+/**
  * dwc3_core_soft_reset - Issues core soft reset and PHY reset
  * @dwc: pointer to our context structure
  */
@@ -281,6 +313,11 @@ int dwc3_core_soft_reset(struct dwc3 *dwc)
 	 */
 	if (dwc->current_dr_role == DWC3_GCTL_PRTCAP_HOST)
 		return 0;
+
+	if (dwc->has_dsm_for_softreset) {
+		dev_dbg(dwc->dev, "calling dwc3_pci_dsm_soft_reset()");
+		return dwc3_pci_dsm_soft_reset(dwc->dev);
+	}
 
 	/*
 	 * If the dr_mode is host and the dwc->current_dr_role is not the
@@ -1554,6 +1591,9 @@ static void dwc3_get_properties(struct dwc3 *dwc)
 
 	dwc->dis_split_quirk = device_property_read_bool(dev,
 				"snps,dis-split-quirk");
+
+	dwc->has_dsm_for_softreset = device_property_read_bool(dev,
+				"snps,has_dsm_for_softreset");
 
 	dwc->lpm_nyet_threshold = lpm_nyet_threshold;
 	dwc->tx_de_emphasis = tx_de_emphasis;

--- a/drivers/usb/dwc3/core.h
+++ b/drivers/usb/dwc3/core.h
@@ -1116,6 +1116,7 @@ struct dwc3_scratchpad_array {
  * @dis_split_quirk: set to disable split boundary.
  * @wakeup_configured: set if the device is configured for remote wakeup.
  * @suspended: set to track suspend event due to U3/L2.
+ * @has_dsm_for_softreset: set if we want to use BIOS to do core soft reset
  * @imod_interval: set the interrupt moderation interval in 250ns
  *			increments or 0 to disable.
  * @max_cfg_eps: current max number of IN eps used across all USB configs.
@@ -1333,6 +1334,8 @@ struct dwc3 {
 	unsigned		async_callbacks:1;
 	unsigned		wakeup_configured:1;
 	unsigned		suspended:1;
+
+	unsigned		has_dsm_for_softreset:1;
 
 	u16			imod_interval;
 

--- a/drivers/usb/dwc3/dwc3-pci.c
+++ b/drivers/usb/dwc3/dwc3-pci.c
@@ -135,6 +135,13 @@ static const struct property_entry dwc3_pci_intel_phy_charger_detect_properties[
 	{}
 };
 
+static const struct property_entry dwc3_pci_intel_bxt_properties[] = {
+	PROPERTY_ENTRY_STRING("dr_mode", "peripheral"),
+	PROPERTY_ENTRY_BOOL("snps,has_dsm_for_softreset"),
+	PROPERTY_ENTRY_BOOL("linux,sysdev_is_parent"),
+	{}
+};
+
 static const struct property_entry dwc3_pci_intel_byt_properties[] = {
 	PROPERTY_ENTRY_STRING("dr_mode", "peripheral"),
 	PROPERTY_ENTRY_BOOL("snps,dis_u2_susphy_quirk"),
@@ -186,6 +193,10 @@ static const struct software_node dwc3_pci_intel_swnode = {
 
 static const struct software_node dwc3_pci_intel_phy_charger_detect_swnode = {
 	.properties = dwc3_pci_intel_phy_charger_detect_properties,
+};
+
+static const struct software_node dwc3_pci_intel_bxt_swnode = {
+	.properties = dwc3_pci_intel_bxt_properties,
 };
 
 static const struct software_node dwc3_pci_intel_byt_swnode = {
@@ -399,9 +410,9 @@ static const struct pci_device_id dwc3_pci_id_table[] = {
 	{ PCI_DEVICE_DATA(INTEL, CMLH, &dwc3_pci_intel_swnode) },
 	{ PCI_DEVICE_DATA(INTEL, SPTLP, &dwc3_pci_intel_swnode) },
 	{ PCI_DEVICE_DATA(INTEL, SPTH, &dwc3_pci_intel_swnode) },
-	{ PCI_DEVICE_DATA(INTEL, BXT, &dwc3_pci_intel_swnode) },
-	{ PCI_DEVICE_DATA(INTEL, BXT_M, &dwc3_pci_intel_swnode) },
-	{ PCI_DEVICE_DATA(INTEL, APL, &dwc3_pci_intel_swnode) },
+	{ PCI_DEVICE_DATA(INTEL, BXT, &dwc3_pci_intel_bxt_swnode) },
+	{ PCI_DEVICE_DATA(INTEL, BXT_M, &dwc3_pci_intel_bxt_swnode) },
+	{ PCI_DEVICE_DATA(INTEL, APL, &dwc3_pci_intel_bxt_swnode) },
 	{ PCI_DEVICE_DATA(INTEL, KBP, &dwc3_pci_intel_swnode) },
 	{ PCI_DEVICE_DATA(INTEL, GLK, &dwc3_pci_intel_swnode) },
 	{ PCI_DEVICE_DATA(INTEL, CNPLP, &dwc3_pci_intel_swnode) },


### PR DESCRIPTION
### Summary

This is a cherry-pick of e65d593a18e7d2699f6e9ca40334db1f7e65ba41.

WI: [AB#2582800](https://dev.azure.com/ni/DevCentral/_workitems/edit/2582800)

### Bug description (from commit message)

The issue is, if core soft reset is issued while Intel Apollo Lake
USB mux is in Host role mode, it takes close to 7 minutes before we
are able to switch USB mux from Host mode to Device mode. This is
due to RTL bug.

The workaround is to let BIOS issue the core soft reset via _DSM
method. It will ensure that USB mux is in Device role mode before
issuing core soft reset, and will inform the driver whether the
reset is success within the timeout value, or the timeout is exceeded.

### Addressed following merge conflicts

[cvadrevu: fix trivial conflict with 047161686b813
 ("usb: dwc3: Add remote wakeup handling")]
[cvadrevu: fix trivial conflict with 4e8ef34e36f28
 ("usb: dwc3: fix gadget mode suspend interrupt handler issue")]
[cvadrevu: fix conflict with 8bea147dfdf82
 ("usb: dwc3: Soft reset phy on probe for host")]
[cvadrevu: fix conflict with 917dc99b65911
 ("usb: dwc3: pci: Change PCI device macros")]


### Testing
- [x] Built kernel with these changes
- [x] Verified that bug occurs on cRIO-9049 without these changes.
- [x] Verified that bug doesn't occur on cRIO-9049 with these changes.