### PR TITLE
printk: nbcon: move locked_port flag to struct uart_port

### DIFF
--- a/include/linux/console.h
+++ b/include/linux/console.h
@@ -304,7 +304,6 @@ struct nbcon_write_context {
  * @nbcon_state:	State for nbcon consoles
  * @nbcon_seq:		Sequence number of the next record for nbcon to print
  * @pbufs:		Pointer to nbcon private buffer
- * @locked_port:	True, if the port lock is locked by nbcon
  * @kthread:		Printer kthread for this console
  * @rcuwait:		RCU-safe wait object for @kthread waking
  * @irq_work:		Defer @kthread waking to IRQ work context
@@ -338,7 +337,6 @@ struct console {
 	atomic_t		__private nbcon_state;
 	atomic_long_t		__private nbcon_seq;
 	struct printk_buffers	*pbufs;
-	bool			locked_port;
 	struct task_struct	*kthread;
 	struct rcuwait		rcuwait;
 	struct irq_work		irq_work;

--- a/include/linux/serial_core.h
+++ b/include/linux/serial_core.h
@@ -488,6 +488,7 @@ struct uart_port {
 	struct uart_icount	icount;			/* statistics */
 
 	struct console		*cons;			/* struct console, if any */
+	bool			nbcon_locked_port;	/* True, if the port is locked by nbcon */
 	/* flags must be updated while holding port mutex */
 	upf_t			flags;
 

--- a/kernel/printk/nbcon.c
+++ b/kernel/printk/nbcon.c
@@ -1586,7 +1586,7 @@ void nbcon_acquire(struct uart_port *up)
 	if (!uart_is_nbcon(up))
 		return;
 
-	WARN_ON_ONCE(con->locked_port);
+	WARN_ON_ONCE(up->nbcon_locked_port);
 
 	do {
 		do {
@@ -1597,7 +1597,7 @@ void nbcon_acquire(struct uart_port *up)
 
 	} while (!nbcon_context_enter_unsafe(&ctxt));
 
-	con->locked_port = true;
+	up->nbcon_locked_port = true;
 }
 EXPORT_SYMBOL_GPL(nbcon_acquire);
 
@@ -1623,13 +1623,13 @@ void nbcon_release(struct uart_port *up)
 		.prio		= NBCON_PRIO_NORMAL,
 	};
 
-	if (!con->locked_port)
+	if (!up->nbcon_locked_port)
 		return;
 
 	if (nbcon_context_exit_unsafe(&ctxt))
 		nbcon_context_release(&ctxt);
 
-	con->locked_port = false;
+	up->nbcon_locked_port = false;
 }
 EXPORT_SYMBOL_GPL(nbcon_release);
 


### PR DESCRIPTION
Console pointer in uart_port might be shared among multiple uart ports. Flag port locked by nbcon should be saved in uart_port structure instead of in console structure.

Fixes: 6424f396c49e ("printk: nbcon: Implement processing in port->lock wrapper")
Suggested-by: John Ogness <john.ogness@linutronix.de>
Signed-off-by: Junxiao Chang <junxiao.chang@intel.com>
Signed-off-by: Sebastian Andrzej Siewior <bigeasy@linutronix.de>
Link: https://lore.kernel.org/all/20240123054033.183114-2-junxiao.chang@intel.com
(cherry picked from commit d4fb86a96cb4a1efd24ca13a2ac234a1c9a3fdc5)
Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>