### PR TITLE
efivarfs: skip efivar_query_variable_info on PREEMPT_RT

### DIFF
--- a/fs/efivarfs/super.c
+++ b/fs/efivarfs/super.c
@@ -35,7 +35,8 @@ static int efivarfs_statfs(struct dentry *dentry, struct kstatfs *buf)
 
 	/* Some UEFI firmware does not implement QueryVariableInfo() */
 	storage_space = remaining_space = 0;
-	if (efi_rt_services_supported(EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO)) {
+	if (efi_rt_services_supported(EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO) &&
+	    !IS_ENABLED(CONFIG_PREEMPT_RT)) {
 		status = efivar_query_variable_info(attr, &storage_space,
 						    &remaining_space,
 						    &max_variable_size);


### PR DESCRIPTION
Commit d86ff3333cb1 ("efivarfs: expose used and total size") introduced the ability to query the efivars file system size with utilities like 'df'.

Unfortunately this introduces large latency spikes in real-time tasks on PREEMPT_RT configured kernels. Skip the EFI run-time services query for EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO if on PREEMPT_RT. The 'df' functionality is lost but the rest of the efivars run-time services continue to work.

Upstream status: Inappropriate (configuration)

  - upstream sets EFI_DISABLE_RUNTIME to 'default y if PREEMPT_RT' thus avoiding the problem entirely.

  - NILRT sets EFI_DISABLE_RUNTIME to 'n' and uses EFI run-time services to access EFI vars at run-time.[1][2]

[1] https://review-board.natinst.com/r/271066
[2] https://review-board.natinst.com/r/303906