### PR TITLE
ni-bluefinLC: Add device tree

### DIFF
--- a/arch/arm/boot/dts/ni-bluefinlc.dts
+++ b/arch/arm/boot/dts/ni-bluefinlc.dts
@@ -1,0 +1,121 @@
+/dts-v1/;
+/include/ "ni-zynq.dtsi"
+
+/* NIDEVCODE 7B37 */
+/* NIDEVCODE 7B38 */
+
+/ {
+	model = "NI Bluefin LC";
+	compatible = "ni,zynq", "xlnx,zynq-7000";
+
+	amba@0 {
+		i2c0: i2c@e0004000 {
+			/* Override ni-zynq.dtsi; we do not have a CPLD at 0x40. */
+			nicpld@40 {
+				status = "disabled";
+			};
+
+			tmp451@4C {
+				compatible = "ti,tmp451";
+				reg = <0x4C>;
+				vcc-supply = <&regulator_vccpint>;
+			};
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* LED_STATUSy on GPIO46 */
+		status {
+			label = "nilrt:status:yellow";
+			gpios = <&gpio 46 0>;
+			default-state = "on";
+		};
+
+		/* LED_ACTIVEg on GPIO47 */
+		active {
+			label = "nilrt:active:green";
+			gpios = <&gpio 47 0>;
+			default-state = "off";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* Reset switch is on GPIO48 */
+		reset_sw@0 {
+			label = "reset_sw";
+			gpios = <&gpio 48 1 /* GPIO_ACTIVE_LOW */>;
+			linux,code = <408>; /* KEY_RESTART */
+			gpio-key,wakeup;
+		};
+	};
+
+	gpio_restart {
+		compatible = "gpio-restart";
+
+		/* ~PS_FORCE_RESET is on GPIO44 */
+		gpios = <&gpio 44 1 /* GPIO_ACTIVE_LOW */>;
+		priority = <200>;
+	};
+
+	dsa@0 {
+		compatible = "marvell,dsa";
+		#address-cells = <2>;
+		#size-cells = <0>;
+
+		dsa,ethernet = <&gem0>;
+		dsa,mii-bus = <&gem0>;
+
+		switch@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			/* MDIO addr 0x0 (single-chip addressing), switch 0 */
+			reg = <0 0>;
+
+			port@0 {
+				reg = <0x0>;
+				label = "cpu";
+			};
+
+			port@1 {
+				reg = <0x1>;
+				label = "sw0";
+				/* phy-handle = <&swport1>; */
+			};
+		};
+	};
+};
+
+&gem0 {
+	status = "okay";
+	emio-speed-gpios = <0>,
+			   <&gpio 54 0>;
+
+	#address-cells = <0x1>;
+	#size-cells = <0x0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+		reg = <0>;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	dr_mode = "host";
+};
+
+&watchdog0 {
+	status = "okay";
+	reset-on-timeout;
+};


### PR DESCRIPTION
Device tree for Bluefin LC devices are for Low-cost Ethernet cDAQ-9183 and cDAQ-9187.
The changes here is to update the model name, NIDEVCODE and removal of dsa switch port 2 (sw1) since Bluefin LC
devices only have a single ethernet port. Otherwise, the rest of the device tree remains the same as Bluefin.

Work item in regards to this change:

- [AB#2733477](https://ni.visualstudio.com/DevCentral/_workitems/edit/2733477)
- [AB#2727840](https://dev.azure.com/ni/DevCentral/_workitems/edit/2727840)


