### PR TITLE
Revert "usb: dwc3: gadget: Add 1ms delay after end transfer command without IOC"

### DIFF
--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -1741,12 +1741,10 @@ static int __dwc3_stop_active_transfer(struct dwc3_ep *dep, bool force, bool int
 	WARN_ON_ONCE(ret);
 	dep->resource_index = 0;
 
-	if (!interrupt) {
-		mdelay(1);
+	if (!interrupt)
 		dep->flags &= ~DWC3_EP_TRANSFER_STARTED;
-	} else if (!ret) {
+	else if (!ret)
 		dep->flags |= DWC3_EP_END_TRANSFER_PENDING;
-	}
 
 	dep->flags &= ~DWC3_EP_DELAY_STOP;
 	return ret;


### PR DESCRIPTION
This reverts commit d8a2bb4eb75866275b5cf7de2e593ac3449643e2.

Commit 4a81bb7a45d4 ("Merge tag 'v6.6.32-rt32' into dev/nilrt/master/6.6_merge")

resolved a conflict with commit ec96bcf5f96a7 ("usb: dwc3: Wait unconditionally after issuing EndXfer command")

in favor of upstream by re-introducing the delay removed by commit c7304f93648d ("Revert "usb: dwc3: gadget: Add 1ms delay after end transfer command without IOC"").

After further testing it was determined this re-introduces the original problem. Revert the (re-introduced) 1ms delay.

Fixes: 4a81bb7a45d4 ("Merge tag 'v6.6.32-rt32' into dev/nilrt/master/6.6_merge")

#### Testing

- [x] built and booted modified kernel on a cRIO-9042
- [x] verified that NI drivers re-version correctly via dkms