### PR TITLE
Update serial_core.c to create an anonymous parent device if parent device pointer is null

### DIFF
--- a/drivers/tty/serial/serial_core.c
+++ b/drivers/tty/serial/serial_core.c
@@ -31,6 +31,7 @@
 
 #include <linux/irq.h>
 #include <linux/uaccess.h>
+#include <linux/platform_device.h>
 
 #include "serial_base.h"
 
@@ -3404,6 +3405,22 @@ int serial_core_register_port(struct uart_driver *drv, struct uart_port *port)
 	 */
 	port->flags |= UPF_DEAD;
 
+	if (port->dev == NULL) {
+		static unsigned int next_port_number;
+		char port_name[21];
+		struct platform_device *pdev;
+
+		snprintf(port_name, sizeof(port_name), "anon_port_%u", next_port_number++);
+		pdev = platform_device_register_simple(port_name, -1, NULL, 0);
+
+		if (PTR_ERR_OR_ZERO(pdev)) {
+			ret = -EINVAL;
+			goto err_unlock;
+		}
+
+		port->dev = &pdev->dev;
+	}
+
 	/* Inititalize a serial core controller device if needed */
 	ctrl_dev = serial_core_ctrl_find(drv, port->dev, port->ctrl_id);
 	if (!ctrl_dev) {
@@ -3440,6 +3457,9 @@ err_unregister_port_dev:
 err_unregister_ctrl_dev:
 	serial_base_ctrl_device_remove(new_ctrl_dev);
 
+	if (strncmp(to_platform_device(port->dev)->name, "anon_port", 9) == 0)
+		platform_device_del(to_platform_device(port->dev));
+
 err_unlock:
 	mutex_unlock(&port_mutex);
 
@@ -3469,6 +3489,9 @@ void serial_core_unregister_port(struct uart_driver *drv, struct uart_port *port
 	/* Drop the serial core controller device if no ports are using it */
 	if (!serial_core_ctrl_find(drv, phys_dev, ctrl_id))
 		serial_base_ctrl_device_remove(ctrl_dev);
+
+	if (strncmp(to_platform_device(phys_dev)->name, "anon_port", 9) == 0)
+		platform_device_del(to_platform_device(phys_dev));
 
 	mutex_unlock(&port_mutex);
 }


### PR DESCRIPTION
niserial987xDriver doesn't pass in a parent device pointer to uartPort when calling uart_add_one_port. This, in turn, crashes the kernel when serial_core attempts to locate the parent device pointer (since the pointer is NULL).

This PR attempts to use platform_device_register_simple to create a platform device that could be assigned as the parent device for NI-987x ports. It does this by checking if the caller is niserial987xDriver. If it is, it gets the slot number of the 987x module, and creates an appropriate platform_device for each uart port that needs to be registered.