### PR TITLE
Revert "HACK sd: Prevent SD from doing high-speed timing"

### DIFF
--- a/drivers/mmc/host/sdhci-pltfm.c
+++ b/drivers/mmc/host/sdhci-pltfm.c
@@ -93,9 +93,6 @@ void sdhci_get_property(struct platform_device *pdev)
 	if (device_property_present(dev, "broken-cd"))
 		host->quirks |= SDHCI_QUIRK_BROKEN_CARD_DETECTION;
 
-	if (device_property_present(dev, "force-sd-standard"))
-		host->quirks |= SDHCI_QUIRK_NO_HISPD_BIT;
-
 	if (device_property_present(dev, "no-1-8-v"))
 		host->quirks2 |= SDHCI_QUIRK2_NO_1_8_V;
 

--- a/drivers/mmc/host/sdhci.c
+++ b/drivers/mmc/host/sdhci.c
@@ -4525,8 +4525,7 @@ int sdhci_setup_host(struct sdhci_host *host)
 	if (host->quirks2 & SDHCI_QUIRK2_HOST_NO_CMD23)
 		mmc->caps &= ~MMC_CAP_CMD23;
 
-	if ((host->caps & SDHCI_CAN_DO_HISPD) &&
-		!(host->quirks & SDHCI_QUIRK_NO_HISPD_BIT))
+	if (host->caps & SDHCI_CAN_DO_HISPD)
 		mmc->caps |= MMC_CAP_SD_HIGHSPEED | MMC_CAP_MMC_HIGHSPEED;
 
 	if ((host->quirks & SDHCI_QUIRK_BROKEN_CARD_DETECTION) &&


### PR DESCRIPTION
This reverts commit 97ebd2d4c626a0952daf25d5d9a7c5e96b6a30f4.

### Justification
The commit being reverted only addressed an issue with the 9607 and 9627, which are both Zynq-7000 based. These devices are still using the 4.14 kernel so the change should be safe to drop from 6.6. The alternative would be to upstream the change, but would likely require some discussion on how to re-implement it since it was initially implemented as a quick hack. More details about the original change can be found [here](https://review-board.natinst.com/r/99036/#comment487189).

[AB#2316653](https://dev.azure.com/ni/DevCentral/_workitems/edit/2316653)