### PR TITLE
github-actions: Add PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,46 @@
+name: PR Checks
+
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 100
+
+      - name: Fetch base_ref
+        run: git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin ${{ github.base_ref }}
+
+      - name: Install build dependencies
+        run: |
+          sudo apt update
+          sudo apt install libelf-dev
+
+      - name: "[TEST] Build nati_x86_64_defconfig"
+        run: |
+          make nati_x86_64_defconfig
+          make -j8 bzImage modules
+
+      - name: "[TEST] Does nati_x86_64_defconfig need update"
+        run: |
+          make savedefconfig
+          diff defconfig arch/x86/configs/nati_x86_64_defconfig
+
+      - name: "[TEST] Is rebase required"
+        run: |
+          common_ancestor=$(git merge-base HEAD origin/${{ github.base_ref }})
+          base_ref_head=$(git log -1 --format=%H origin/${{ github.base_ref }})
+
+          [ $common_ancestor == $base_ref_head ]
+
+      - name: "[TEST] Run checkpatch.pl"
+        run: |
+          common_ancestor=$(git merge-base HEAD origin/${{ github.base_ref }})
+          git format-patch $common_ancestor
+          ./scripts/checkpatch.pl *patch


### PR DESCRIPTION
Add GitHub actions to do PR sanity checks.

### Testing
[PR build](https://github.com/chaitu236/linux/actions/runs/13511984004/job/37753806520) in my repo - the failure in "Run checkpatch.pl" step is expected as newly added files without MAINTAINERS file update cause warnings from checkpatch.

It is not clear to my why the action doesn't run in this repo, but it is possible that it's just that this has to be merged to this repo first for actions to be enabled.