### PR TITLE
mtd: Create gluebi mtdblocks if CONFIG_FTL is not enabled

### DIFF
--- a/drivers/mtd/mtd_blkdevs.c
+++ b/drivers/mtd/mtd_blkdevs.c
@@ -463,7 +463,8 @@ static void blktrans_notify_add(struct mtd_info *mtd)
 {
 	struct mtd_blktrans_ops *tr;
 
-	if (mtd->type == MTD_ABSENT || mtd->type == MTD_UBIVOLUME)
+	if (mtd->type == MTD_ABSENT ||
+	   (IS_ENABLED(CONFIG_FTL) && mtd->type == MTD_UBIVOLUME))
 		return;
 
 	list_for_each_entry(tr, &blktrans_majors, list)
@@ -503,7 +504,8 @@ int register_mtd_blktrans(struct mtd_blktrans_ops *tr)
 	mutex_lock(&mtd_table_mutex);
 	list_add(&tr->list, &blktrans_majors);
 	mtd_for_each_device(mtd)
-		if (mtd->type != MTD_ABSENT && mtd->type != MTD_UBIVOLUME)
+		if (mtd->type != MTD_ABSENT &&
+		   !(IS_ENABLED(CONFIG_FTL) && mtd->type == MTD_UBIVOLUME))
 			tr->add_mtd(tr, mtd);
 	mutex_unlock(&mtd_table_mutex);
 	return 0;


### PR DESCRIPTION
WI: [AB#3024196](https://ni.visualstudio.com/DevCentral/_workitems/edit/3024196)

Bluefin devices expect to mount mtdblock devices created by gluebi at runtime, but https://github.com/ni/linux/commit/cfd7c9d260dc0a3baaea05a122a19ab91e193c65 prevents gluebi from creating these mtdblock devices as a mitigation to a NULL pointer dereference caused by FTL notifier. As a workaround, this commit adds a check for `CONFIG_FTL` before doing so, keeping the solution intact if `CONFIG_FTL` is enabled, while allowing the creation of gluebi mtdblock devices if `CONFIG_FTL` is not enabled. 

Testing: Built and deployed kernel with changes on cDAQ-9189, verified that mtdblocks are enumerated for gluebi mtd partitions when `CONFIG_FTL` is not enabled. 