### PR TITLE
pl35x-nand-controller: Enable dynamically setting clk rate in NAND.

### DIFF
--- a/arch/arm/boot/dts/xilinx/ni-zynq.dtsi
+++ b/arch/arm/boot/dts/xilinx/ni-zynq.dtsi
@@ -140,6 +140,16 @@
 
 &smcc {
 	status = "okay";
+	/*
+	 * NI Zynq based devices require different memclk frequency
+	 * for different timing modes
+	 */
+	memclk-timing-frequency = <0 83333333>,
+				<1 166666666>,
+				<2 166666666>,
+				<3 166666666>,
+				<4 166666666>,
+				<5 166666666>;
 };
 
 &nfc0 {

--- a/drivers/mtd/nand/raw/pl35x-nand-controller.c
+++ b/drivers/mtd/nand/raw/pl35x-nand-controller.c
@@ -795,6 +795,28 @@ static int pl35x_nfc_exec_op(struct nand_chip *chip,
 				      op, check_only);
 }
 
+static unsigned long of_get_memclk_freq(const struct device_node *np, const int timing_mode)
+{
+	int memclk_frequency, i, total_elements;
+	u32 memclk_mode;
+
+	total_elements = of_property_count_u32_elems(np, "memclk-timing-frequency");
+	if (total_elements <= 0)
+		return 0;
+
+	for (i = 0; i < total_elements; i = i+2) {
+		of_property_read_u32_index(np, "memclk-timing-frequency", i, &memclk_mode);
+		if (memclk_mode == timing_mode) {
+			of_property_read_u32_index(np, "memclk-timing-frequency",
+				i+1, &memclk_frequency);
+			return memclk_frequency;
+		}
+	}
+
+	pr_err("Failed to find matching memclk timing mode %d\n", timing_mode);
+	return 0;
+}
+
 static int pl35x_nfc_setup_interface(struct nand_chip *chip, int cs,
 				     const struct nand_interface_config *conf)
 {
@@ -804,6 +826,8 @@ static int pl35x_nfc_setup_interface(struct nand_chip *chip, int cs,
 	const struct nand_sdr_timings *sdr;
 	unsigned int period_ns, val;
 	struct clk *mclk;
+	unsigned long memclk_of_timing_freq;
+	int ret = 0;
 
 	sdr = nand_get_sdr_timings(conf);
 	if (IS_ERR(sdr))
@@ -813,6 +837,23 @@ static int pl35x_nfc_setup_interface(struct nand_chip *chip, int cs,
 	if (IS_ERR(mclk)) {
 		dev_err(nfc->dev, "Failed to retrieve SMC memclk\n");
 		return PTR_ERR(mclk);
+	}
+
+	/*
+	 * NI Zynq based devices require different rates for different timing modes
+	 * so we need to set the rate according to the timing modes
+	 */
+	memclk_of_timing_freq = of_get_memclk_freq(
+		nfc->dev->parent->of_node,
+		conf->timings.mode);
+
+	if (memclk_of_timing_freq) {
+		ret = clk_set_rate(mclk, memclk_of_timing_freq);
+		if (ret) {
+			pr_err("Failed to set memclk timing frequency to %lu\n",
+				memclk_of_timing_freq);
+			return ret;
+		}
 	}
 
 	/*


### PR DESCRIPTION
NI Zynq based devices require different nand memclk frequencies to be set at different timing modes, as seen in the bluefin branch of [ni-zynq.dtsi](https://github.com/ni/linux/blob/2dc2aab3edd7c68cc7f96955a7763e618725c03e/arch/arm/boot/dts/ni-zynq.dtsi#L166).
 This commit enables the memclk rate to be set according to the specifications in the device tree. If the device tree does not have this memclk-timing-frequency property specified, the driver proceeds as usual.
 
WI:  [AB#3024184](https://dev.azure.com/ni/DevCentral/_workitems/edit/3024184)

 Testing: 
 
 Tested my changes on cDAQ9189, NAND timing mode was able to be set successfully and NAND device was detected.
 
![image](https://github.com/user-attachments/assets/096fae12-41c0-40b5-97e0-85173b24e2e1)

Tested with memclk-timing-frequency property not set in device tree and we get the error as expected. This printk error message is not part of the commit, just there for my own checking. Purposely not including it in the commit as it is not actually an error if the device does not have that property.
![image](https://github.com/user-attachments/assets/24f74c61-4c7e-4118-998d-af9401ea0f31)

Tested with passing a non-existent timing mode (99) into the timing mode parameter of of_get_memclk_freq. Got the expected error.
![image](https://github.com/user-attachments/assets/1d5d4c19-6085-4974-a158-50255da98b19)


