### PR TITLE
ARM: dts: ni-zynq: Enable I2C Bus by default

### DIFF
--- a/arch/arm/boot/dts/xilinx/ni-zynq.dtsi
+++ b/arch/arm/boot/dts/xilinx/ni-zynq.dtsi
@@ -118,6 +118,8 @@
 };
 
 &i2c0 {
+	status = "okay";
+
 	nicpld@40 {
 		compatible = "ni,cpld";
 		reg = <0x40>;


### PR DESCRIPTION
Enable I2C bus 0 by default for NI Zynq-based devices. A follow-up to device tree tweaks introduced in https://github.com/ni/linux/pull/192/ to get NI Zynq device trees to build correctly based on updated zynq-7000.dtsi definitions. i2c0 is disabled by default in zynq-7000.dtsi, so this node needs to be explicitly enabled to work. 

Testing: Deployed changes on cDAQ-9189, verified enumeration of /dev/i2c-0 and communication with on-board tmp451 sensor via sysfs. 