### PR TITLE
usb: dwc3: Remove mdelay to fix USBLAN issue

### DIFF
--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -438,9 +438,17 @@ skip_status:
 			dwc3_gadget_ep_get_transfer_index(dep);
 	}
 
+	/*
+	 * mdelay below breaks USBLAN in cRIO-9041 and other devices. Commenting
+	 * out instead of removing so git doesn't drop this silently during
+	 * upstream merges if upstream moves this to a different place in
+	 * future.
+	 *
+	 * AB#2419039
+	 */
 	if (DWC3_DEPCMD_CMD(cmd) == DWC3_DEPCMD_ENDTRANSFER &&
 	    !(cmd & DWC3_DEPCMD_CMDIOC))
-		mdelay(1);
+		; /* mdelay(1); */
 
 	if (saved_config) {
 		reg = dwc3_readl(dwc->regs, DWC3_GUSB2PHYCFG(0));


### PR DESCRIPTION
cRIO-9041, cRIO-9034 and possibly other devices' USBLAN does not work with this mdelay in place when connected to Windows host.

WI: [AB#2419039](https://dev.azure.com/ni/DevCentral/_workitems/edit/2419039).
WI: [AB#3051331](https://dev.azure.com/ni/DevCentral/_workitems/edit/3051331/)

We previously had fix for this in 6.6 kernel https://github.com/ni/linux/pull/133 by reverting an upstream commit but upstream moved the delay to a different place in https://github.com/ni/linux/commit/c3d3501cf896cd6b75f9b018d59247322ac5a4eb and we accidentally kept the new changes in https://github.com/ni/linux/pull/184.

### Testing
- [x] Verified on cRIO-9041 that USBLAN issue doesn't occur anymore.
- [x] Verified that 6.12 kernels also require this fix [AB#3051331](https://dev.azure.com/ni/DevCentral/_workitems/edit/3051331/).

### Note
- Needs cherry-picking to `nilrt/25.3/6.6`.
- Needs cherry-picking to `nilrt/master/6.12`.