### PR TITLE
ARM: dts: ni-bluefin: Specify mv88e6341 switch PHYs

### DIFF
--- a/arch/arm/boot/dts/xilinx/ni-bluefin.dts
+++ b/arch/arm/boot/dts/xilinx/ni-bluefin.dts
@@ -105,19 +105,31 @@
 			port@1 {
 				reg = <1>;
 				label = "sw0";
-				fixed-link {
-					speed = <1000>;
-					full-duplex;
-				};
+				phy-handle = <&swphy1>;
 			};
 
 			port@2 {
 				reg = <2>;
 				label = "sw1";
-				fixed-link {
-					speed = <1000>;
-					full-duplex;
-				};
+				phy-handle = <&swphy2>;
+			};
+		};
+
+		mdio {
+			swphy1: ethernet-phy@11 {
+				reg = <0x11>;
+			};
+
+			swphy2: ethernet-phy@12 {
+				reg = <0x12>;
+			};
+
+			swphy3: ethernet-phy@13 {
+				reg = <0x13>;
+			};
+
+			swphy4: ethernet-phy@14 {
+				reg = <0x14>;
 			};
 		};
 	};


### PR DESCRIPTION
WI: [AB#2918589](https://dev.azure.com/ni/DevCentral/_workitems/edit/2918589)

Discovered an issue with Bluefin ethernet interface not detecting link up/down correctly due to missing PHY enumeration. Specifying PHY for both ports resolves this issue.

Testing: Deployed kernel changes on 9189, verify that ethernet functionality and link status correctness based on presence of ethernet connection to both ports. 