### PR TITLE
ARM: pl35x-nand-controller: Fix subpage read performance

### DIFF
--- a/drivers/mtd/nand/raw/pl35x-nand-controller.c
+++ b/drivers/mtd/nand/raw/pl35x-nand-controller.c
@@ -670,7 +670,7 @@ disable_ecc_engine:
 static int pl35x_nand_read_subpage_raw(struct nand_chip *chip, uint32_t data_offs,
 				       uint32_t readlen, uint8_t *bufpoi, int page)
 {
-	return nand_monolithic_read_page_raw(chip, bufpoi, 0, page);
+	return nand_read_page_op(chip, page, data_offs, bufpoi + data_offs, readlen);
 }
 
 static int pl35x_nand_exec_op(struct nand_chip *chip,


### PR DESCRIPTION
When timing sha256sum operations on Bluefin devices running Linux 6.6, a discrepancy in system CPU time was found:

Linux 4.1:
```
admin@cDAQ9189-215689B:~# time sha256sum /dev/mtdblock8
c0660b8c34d025943654d732aad8b04083b3d0dd69a114ff95df74217d111f2e  /dev/mtdblock8
 
real    0m9.416s
user    0m5.440s
sys     0m3.920s
```

Linux 6.6
```
admin@cDAQ9189-215689B:~# time sha256sum /dev/mtdblock8
c0660b8c34d025943654d732aad8b04083b3d0dd69a114ff95df74217d111f2e  /dev/mtdblock8
 
real    0m24.671s
user    0m5.639s
sys     0m18.025s
```

The issue was traced back to nand subpage read implementation, where a full raw page read was performed instead of a subpage read. This is resolved by replacing the `nand_monolithic_read_page_raw` with a `nand_read_page_op` call and passing the corresponding read length and data offset. Change tested on cDAQ-9189:

```
admin@cDAQ9189-215689B:/boot# time sha256sum /dev/mtdblock8
c0660b8c34d025943654d732aad8b04083b3d0dd69a114ff95df74217d111f2e  /dev/mtdblock8
 
real    0m13.199s
user    0m5.813s
sys     0m6.477s
```