### PR TITLE
[WIP] nati_slsc_12001_dts: Add device tree for SLSC and other related changes.

### DIFF
--- a/arch/arm/boot/dts/ni-slsc.dts
+++ b/arch/arm/boot/dts/ni-slsc.dts
@@ -1,0 +1,599 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/include/ "ni-zynq.dtsi"
+
+/* NIDEVCODE 775E */
+
+/ {
+	model = "NI SLSC";
+	compatible = "ni,zynq", "xlnx,zynq-7000";
+
+	aliases {
+		spi1  = &spiController1;
+		/*spi2  = &spiController2;*/ /*confilct irq, disabled temporarily*/
+		spi3  = &spiController3;
+		spi4  = &spiController4;
+		spi5  = &spiController5;
+		spi6  = &spiController6;
+		spi7  = &spiController7;
+		spi8  = &spiController8;
+		spi9  = &spiController9;
+		spi10 = &spiController10;
+		spi11 = &spiController11;
+		spi12 = &spiController12;
+	};
+
+	amba@0 {
+
+		gpio: gpio@e000a000 {
+			/* You can specify GPIO settings here:
+			 *
+			 *  gpioN-label	  String label.
+			 *  gpioN-direction  "input" or "output".
+			 *  gpioN-settings   "output" - specifies the GPIO state as "high"
+			 *				or "low".
+			 *		     "input"  - specifies GPIO interrupt settings as
+			 *				none", "level-low", "level-high",
+			 *				"edge-falling", "edge-rising", or
+			 *				edge-both".
+			 */
+
+			/* GPIO1 (MIO1) */
+			gpio1-label	 = "eth0_phy_interrupt";
+			gpio1-direction = "input";
+			gpio1-settings  = "level-low";
+
+			/* GPIO15 (MIO15) */
+			gpio15-label	 = "wdt_interrupt";
+			gpio15-direction = "input";
+			gpio15-settings  = "edge-falling";
+
+			/* GPIO54 (EMIO0) */
+			gpio54-label	 = "eth0_link_speed";
+			gpio54-direction = "output";
+			gpio54-settings  = "low";
+
+			/* GPIO55 (EMIO1) */
+			gpio55-label	 = "eth1_link_speed_1000";
+			gpio55-direction = "output";
+			gpio55-settings  = "low";
+
+			/* GPIO56 (EMIO2) */
+			gpio56-label	 = "eth1_link_speed_100";
+			gpio56-direction = "output";
+			gpio56-settings  = "low";
+
+			/* GPIO57 (EMIO3) */
+			gpio57-label	 = "eth1_phy_interrupt";
+			gpio57-direction = "input";
+			gpio57-settings  = "level-low";
+		};
+
+		i2c0: i2c@e0004000 {
+			nicpld@40 {
+				watchdogs {
+					boot-watchdog {
+						interrupt-parent = <&gpio>;
+						interrupts = <15 0>;
+					};
+				};
+
+				leds {
+					status-0 {
+						label = "nilrt:status:yellow";
+						max-brightness = <0xFFFF>;
+					};
+					eth0-0 {
+						label = "nilrt:eth0:green";
+						linux,default-trigger =
+						  "e000b000.etherne:00:100Mb";
+					};
+					eth0-1 {
+						label = "nilrt:eth0:yellow";
+						linux,default-trigger =
+						  "e000b000.etherne:00:Gb";
+					};
+				};
+			};
+
+			ds3231_rtc@68 {
+				status = "okay";
+			};
+		};
+
+
+		spiController1: spi@0x80001000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80001000 0x1000>;
+			interrupts = <0 29 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot1";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible ="rohm,dh2228fv"; /*spidev cannot be used directly*/
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		/*confilct irq @0x80002000, disabled temproarily*/
+		/*
+		 *spiController2: spi@0x80002000 {
+		 *	compatible = "cdns,spi-r1p6";
+		 *	status = "okay";
+		 *	reg = <0x80002000 0x1000>;
+		 *	interrupts = <0 30 4>;
+		 *	clock-names = "ref_clk", "pclk";
+		 *	clocks = <&clkc 25>, <&clkc 34>;
+		 *	#address-cells = <1>;
+		 *	#size-cells = <0>;
+		 *
+		 *	m25p80@0 {
+		 *		#address-cells = <1>;
+		 *		#size-cells = <1>;
+		 *		compatible = "m25p80","jedec,spi-nor";
+		 *		reg = <0>;
+		 *		spi-max-frequency = <5000000>;
+		 *
+		 *		partition@0 {
+		 *			label = "slsc_slot2";
+		 *			reg = <0x0 0x1000000>;
+		 *		};
+		 *	};
+		 *
+		 *
+		 *	spidev@1 {
+		 *		compatible = "rohm,dh2228fv";
+		 *		spi-max-frequency = <1000000>;
+		 *		reg = <1>;
+		 *	};
+		 *};
+		 */
+
+		spiController3: spi@0x80003000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80003000 0x1000>;
+			interrupts = <0 31 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot3";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "rohm,dh2228fv";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController4: spi@0x80004000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80004000 0x1000>;
+			interrupts = <0 32 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot4";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController5: spi@0x80005000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80005000 0x1000>;
+			interrupts = <0 33 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot5";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController6: spi@0x80006000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80006000 0x1000>;
+			interrupts = <0 34 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot6";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController7: spi@0x80007000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80007000 0x1000>;
+			interrupts = <0 35 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot7";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController8: spi@0x80008000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80008000 0x1000>;
+			interrupts = <0 36 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot8";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController9: spi@0x80009000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80009000 0x1000>;
+			interrupts = <0 52 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot9";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController10: spi@0x8000A000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x8000A000 0x1000>;
+			interrupts = <0 53 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot10";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController11: spi@0x8000B000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x8000B000 0x1000>;
+			interrupts = <0 54 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot11";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController12: spi@0x8000C000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x8000C000 0x1000>;
+			interrupts = <0 55 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				partition@0 {
+					label = "slsc_slot12";
+					reg = <0x0 0x1000000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+	};
+
+
+};
+
+&gem0 {
+	status = "okay";
+
+	/* No fpga_clk specified because we want our FPGA clock
+	 * (fclk0) to always be 125 MHz. The bootloader sets
+	 * fclk0 to 125 MHz and we just leave it like that.
+	 */
+
+	phy-handle = <&phy0>;
+	phy-mode = "rgmii-id";
+	#address-cells = <0x1>;
+	#size-cells = <0x0>;
+
+	cdns,emio-gpio-speed-1000 = <54>;
+
+	phy0: phy@0 {
+		compatible = "micrel,KSZ9031";
+		device_type = "ethernet-phy";
+		reg = <0x0>;
+		/* Interrupt on GPIO1. */
+		interrupts = <1 0>;
+		interrupt-parent = <&gpio>;
+
+		/* Set RX_CLK Pad Skew [4:0] to 0b00000. */
+		rxc-skew-ps = <0>;
+	};
+};
+
+&gem1 {
+	status = "okay";
+
+	/* No fpga_clk specified because we want our FPGA clock (fclk0) to
+	 * always be 125 MHz. The bootloader sets fclk0 to 125 MHz and we just
+	 * leave it like that.
+	 */
+
+	phy-handle = <&phy1>;
+	phy-mode = "rgmii-id";
+	#address-cells = <0x1>;
+	#size-cells = <0x0>;
+
+	cdns,emio-gpio-speed-1000 = <55>;
+	cdns,emio-gpio-speed-100 = <56>;
+
+	phy1: phy@1 {
+		compatible = "micrel,KSZ9031";
+		device_type = "ethernet-phy";
+		reg = <0x1>;
+		/* Interrupt on GPIO57. */
+		interrupts = <57 0>;
+		interrupt-parent = <&gpio>;
+	};
+};
+
+&sdhci0 {
+	status = "okay";
+};
+
+&ni_uart0 {
+	status = "okay";
+	transceiver = "RS-232";
+};
+
+&ni_uart1 {
+	status = "okay";
+	transceiver = "RS-232";
+};
+
+&ni_uart2 {
+	status = "okay";
+	transceiver = "RS-232";
+};
+
+&ni_uart3 {
+	status = "okay";
+	transceiver = "RS-232";
+};
+
+&ni_uart4 {
+	status = "okay";
+	transceiver = "RS-485";
+};
+
+&ni_uart5 {
+	status = "okay";
+	transceiver = "RS-485";
+};
+
+&can0 {
+	status = "okay";
+};
+
+&can1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	dr_mode = "peripheral";
+};
+
+&usb1 {
+	status = "okay";
+	dr_mode = "host";
+};
+
+&clkc {
+	/* Enable fclk0 for eth0 and eth1, fclk1 for serial. */
+	fclk-enable = <0x3>;
+};


### PR DESCRIPTION
migrated nati_slsc_dts related changes from branch [dev/slsc/1.0/4.1](http://git.natinst.com/cgit/linux/log/?h=dev/slsc/1.0/4.1) to ni/linux repo branch [nilrt/master/6.6](https://github.com/ni/linux/tree/nilrt/master/6.6).

WI: [AB#3014043](https://dev.azure.com/ni/DevCentral/_workitems/edit/3014043)

Testing:
Current state: cherry pick and push one commit at one time to check for PR checker build error.
manually built kernel with cherry picked commits.
required to add nati_slsc_defconfig to build pass.