### PR TITLE
ARM: ni-slsc-12001.dts: Add device tree for SLSC

### DIFF
--- a/arch/arm/boot/dts/ni-slsc-12001.dts
+++ b/arch/arm/boot/dts/ni-slsc-12001.dts
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/include/ "ni-zynq.dtsi"
+
+/* NIDEVCODE 78AA */
+
+/ {
+	model = "NI SLSC-12001";
+	compatible = "ni,zynq", "xlnx,zynq-7000";
+
+	aliases {
+		spi1  = &spiController1;
+		spi2  = &spiController2;
+		spi3  = &spiController3;
+		spi4  = &spiController4;
+		spi5  = &spiController5;
+		spi6  = &spiController6;
+		spi7  = &spiController7;
+		spi8  = &spiController8;
+		spi9  = &spiController9;
+		spi10 = &spiController10;
+		spi11 = &spiController11;
+		spi12 = &spiController12;
+	};
+
+	amba@0 {
+
+		gpio: gpio@e000a000 {
+			/* You can specify GPIO settings here:
+			 *
+			 *  gpioN-label      String label.
+			 *  gpioN-direction  "input" or "output".
+			 *  gpioN-settings   "output" - specifies the GPIO state as "high"
+			 *                              or "low".
+			 *                   "input"  - specifies GPIO interrupt settings as
+			 *                              "none", "level-low", "level-high",
+			 *                              "edge-falling", "edge-rising", or
+			 *                              "edge-both".
+			 */
+
+			/* GPIO1 (MIO1) */
+			gpio1-label     = "eth0_phy_interrupt";
+			gpio1-direction = "input";
+			gpio1-settings  = "level-low";
+
+			/* GPIO15 (MIO15) */
+			gpio15-label     = "wdt_interrupt";
+			gpio15-direction = "input";
+			gpio15-settings  = "edge-falling";
+
+			/* GPIO54 (EMIO0) */
+			gpio54-label     = "eth0_link_speed";
+			gpio54-direction = "output";
+			gpio54-settings  = "low";
+
+			/* GPIO55 (EMIO1) */
+			gpio55-label     = "eth1_link_speed_1000";
+			gpio55-direction = "output";
+			gpio55-settings  = "low";
+
+			/* GPIO56 (EMIO2) */
+			gpio56-label     = "eth1_link_speed_100";
+			gpio56-direction = "output";
+			gpio56-settings  = "low";
+
+			/* GPIO57 (EMIO3) */
+			gpio57-label     = "eth1_phy_interrupt";
+			gpio57-direction = "input";
+			gpio57-settings  = "level-low";
+		};
+
+		i2c0: i2c@e0004000 {
+			nicpld@40 {
+				watchdogs {
+					boot-watchdog {
+						interrupt-parent = <&gpio>;
+						interrupts = <15 2 /* IRQ_TYPE_EDGE_FALLING */>;
+					};
+				};
+
+				leds {
+					status-0 {
+						label = "nilrt:status:yellow";
+						max-brightness = <0xFFFF>;
+					};
+					eth0-0 {
+						label = "nilrt:eth0:green";
+						linux,default-trigger =
+						  "e000b000.etherne:00:100Mb";
+					};
+					eth0-1 {
+						label = "nilrt:eth0:yellow";
+						linux,default-trigger =
+						  "e000b000.etherne:00:Gb";
+					};
+				};
+			};
+
+			ds3231_rtc@68 {
+				status = "okay";
+			};
+		};
+
+		i2c1: i2c@e0005000 {
+			status = "okay";
+
+			ad7291_adc@2c {
+				compatible = "ad7291";
+				status = "okay";
+				reg = <0x2C>;
+			};
+		} ;
+
+		spiController1: spi@0x80001000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80001000 0x1000>;
+			interrupts = <0 31 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot1";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible ="spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController2: spi@0x80002000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80002000 0x1000>;
+			interrupts = <0 32 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot2";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController3: spi@0x80003000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80003000 0x1000>;
+			interrupts = <0 33 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot3";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController4: spi@0x80004000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80004000 0x1000>;
+			interrupts = <0 34 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot4";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController5: spi@0x80005000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80005000 0x1000>;
+			interrupts = <0 35 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot5";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController6: spi@0x80006000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80006000 0x1000>;
+			interrupts = <0 36 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot6";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController7: spi@0x80007000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80007000 0x1000>;
+			interrupts = <0 52 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot7";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController8: spi@0x80008000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80008000 0x1000>;
+			interrupts = <0 53 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot8";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController9: spi@0x80009000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x80009000 0x1000>;
+			interrupts = <0 54 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot9";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		spiController10: spi@0x8000A000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x8000A000 0x1000>;
+			interrupts = <0 55 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot10";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController11: spi@0x8000B000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x8000B000 0x1000>;
+			interrupts = <0 56 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot11";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+
+		spiController12: spi@0x8000C000 {
+			compatible = "cdns,spi-r1p6";
+			status = "okay";
+			reg = <0x8000C000 0x1000>;
+			interrupts = <0 57 4>;
+			clock-names = "ref_clk", "pclk";
+			clocks = <&clkc 25>, <&clkc 34>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "m25p80","jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				partition@0 {
+					label = "slsc_slot12";
+					reg = <0x0 0x100000>;
+				};
+			};
+
+
+			spidev@1 {
+				compatible = "spidev";
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+
+		slscfpga@80000000 {
+		   compatible = "ni,slscfpga";
+		   reg = <0x80000000 0x30000>;
+		   interrupts = <0 29 4>;
+		};
+
+	};
+
+
+};
+
+&gem0 {
+		status = "okay";
+
+		/* No fpga_clk specified because we want our FPGA clock
+		 * (fclk0) to always be 125 MHz. The bootloader sets
+		 * fclk0 to 125 MHz and we just leave it like that.
+		 */
+
+		phy-handle = <&phy0>;
+		phy-mode = "rgmii-id";
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		emio-speed-gpios = <0>,
+						   <&gpio 54 0>;
+
+		phy0: phy@0 {
+				compatible = "micrel,KSZ9031";
+				device_type = "ethernet-phy";
+				reg = <0x0>;
+				/* Interrupt on GPIO1. */
+				interrupts = <1 8 /* IRQ_TYPE_LEVEL_LOW */>;
+				interrupt-parent = <&gpio>;
+
+				/* Set RX_CLK Pad Skew [4:0] to 0b00000. */
+				rxc-skew-ps = <0>;
+		};
+};
+
+&sdhci0 {
+		status = "okay";
+};
+
+&ni_uart0 {
+		status = "okay";
+		transceiver = "RS-232";
+};
+
+&usb1 {
+		status = "okay";
+		dr_mode = "host";
+};
+
+&clkc {
+		/* Enable fclk0 for eth0 and eth1, fclk1 for serial. */
+		fclk-enable = <0x3>;
+};

--- a/arch/arm/boot/dts/xilinx/ni-slsc-12001.dts
+++ b/arch/arm/boot/dts/xilinx/ni-slsc-12001.dts
@@ -69,48 +69,6 @@
 			gpio57-settings  = "level-low";
 		};
 
-		i2c0: i2c@e0004000 {
-			nicpld@40 {
-				watchdogs {
-					boot-watchdog {
-						interrupt-parent = <&gpio>;
-						interrupts = <15 2 /* IRQ_TYPE_EDGE_FALLING */>;
-					};
-				};
-
-				leds {
-					status-0 {
-						label = "nilrt:status:yellow";
-						max-brightness = <0xFFFF>;
-					};
-					eth0-0 {
-						label = "nilrt:eth0:green";
-						linux,default-trigger =
-						  "e000b000.etherne:00:100Mb";
-					};
-					eth0-1 {
-						label = "nilrt:eth0:yellow";
-						linux,default-trigger =
-						  "e000b000.etherne:00:Gb";
-					};
-				};
-			};
-
-			ds3231_rtc@68 {
-				status = "okay";
-			};
-		};
-
-		i2c1: i2c@e0005000 {
-			status = "okay";
-
-			ad7291_adc@2c {
-				compatible = "ad7291";
-				status = "okay";
-				reg = <0x2C>;
-			};
-		} ;
-
 		spiController1: spi@0x80001000 {
 			compatible = "cdns,spi-r1p6";
 			status = "okay";
@@ -528,6 +486,50 @@
 				/* Set RX_CLK Pad Skew [4:0] to 0b00000. */
 				rxc-skew-ps = <0>;
 		};
+};
+
+&i2c0 {
+	/* Override ni-zynq.dtsi */
+	nicpld@40 {
+		watchdogs {
+			boot-watchdog {
+				interrupt-parent = <&gpio>;
+				interrupts = <15 2 /* IRQ_TYPE_EDGE_FALLING */>;
+			};
+		};
+
+		leds {
+			status-0 {
+				label = "nilrt:status:yellow";
+				max-brightness = <0xFFFF>;
+			};
+			eth0-0 {
+				label = "nilrt:eth0:green";
+				linux,default-trigger =
+				  "e000b000.etherne:00:100Mb";
+			};
+			eth0-1 {
+				label = "nilrt:eth0:yellow";
+				linux,default-trigger =
+				  "e000b000.etherne:00:Gb";
+			};
+		};
+	};
+
+	ds3231_rtc@68 {
+		status = "okay";
+	};
+};
+
+&i2c1 {
+	/* Override ni-zynq.dtsi */
+	status = "okay";
+
+	ad7291_adc@2c {
+		compatible = "ad7291";
+		status = "okay";
+		reg = <0x2C>;
+	};
 };
 
 &sdhci0 {


### PR DESCRIPTION
migrated ni-slsc-12001.dts related changes from branch [dev/slsc/1.0/4.1](http://git.natinst.com/cgit/linux/log/?h=dev/slsc/1.0/4.1) to ni/linux repo branch [nilrt/master/6.6](https://github.com/ni/linux/tree/nilrt/master/6.6).

**The commits:**
[33bb24ec422d56e](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=33bb24ec422d56ef7d69b0f33cfbe8da397df52a) nati_slsc_dts: Add device tree for SLSC
[bd53913ffd7ca2c](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=bd53913ffd7ca2c03f93db3c144ebae29282409b) nati_slsc_dts: Correct SPI settings on device tree
[9cf417b917ca50c](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=9cf417b917ca50cbc57227c73dd9c9f03e429fce) nati_slsc_dts: fix IRQ for spi7/8
[4a9c9dedc9c57d1](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=4a9c9dedc9c57d115a25aa59377b766b6b8dd85e) nati_slsc_dts: Add SLSC FPGA to Device Tree
[05d7cb71400076f](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=05d7cb71400076f1e75714d32f3cec193b0ac112) nati_slsc_dts: Remove trailing whitespace
[85377cbaf33a07c](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=85377cbaf33a07c7b68c88337bfee41043f6b1f6) nati_slsc_dts: Correct device info in device tree
[489cdc8c332e7f6](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=489cdc8c332e7f631acd2efdc2a36dc7276a963d) nati_slsc_dts: pull in Tecate dts for 4.1 Linux kernel
[3dac1d2e2886d11](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=3dac1d2e2886d11bbcb3b4f6682d8367aa874b25) nati_slsc_dts: Remove unused devices in dts
[4740c7033c40894](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=4740c7033c408941ca5bad7d67a66350da260208) nati_slsc_dts: Use spidev as compatible type in dts
[297230220f55b18](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=297230220f55b189e5b705c132427e42fd9794c7) nati_slsc_12001_dts: Rename dts file with model name
[31600f928cd20af](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=31600f928cd20af6b55e4e172316c18f1a7f11a5) nati_slsc_12001_dts: Fix the format of the dts
[e3a89e6e7022b6e](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=e3a89e6e7022b6e9683bafa80293532d9a916762) nati_slsc_12001_dts: set SLSC FPGA compatible id to ni,slscfpga
[a5f550aed87eb66](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=a5f550aed87eb6605de0a162185da70753381d05) nati_slsc_12001_dts: Add AD7291 ADC to device tree
[b662f5d16e2e2f4](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=b662f5d16e2e2f496b7d885bf6a272b8fa788fb0) nati_slsc_12001_dts: Enforce level trigger for slscfpga IRQ
[5fd9c31cd9ac578](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=5fd9c31cd9ac578742fc6763082b69a13942809a) nati_slsc_12001_dts: Reduce SPI max frequency m25p80 device

**Additional:**
removed execute permissions of ni-slsc-12001.dts file.
added SPDX-License-Identifier on top of the file.
move the file to xilinx folder.
update i2c bindings.

there will be separate PR for [01206af5a8ba](http://git.natinst.com/cgit/linux/commit/?h=dev/slsc/1.0/4.1&id=01206af5a8ba6cc481a21fdd1ae01327c10975a8) commit where the patch involved both nati_slsc_defconfig and ni-slsc-12001.dts.

WI: [AB#3014043](https://dev.azure.com/ni/DevCentral/_workitems/edit/3014043)