### PR TITLE
Revert "mmc: core: Wait for Vdd to settle on card power off"

### DIFF
--- a/drivers/mmc/host/sdhci.c
+++ b/drivers/mmc/host/sdhci.c
@@ -2378,9 +2378,6 @@ void sdhci_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
 	else
 		sdhci_set_power(host, ios->power_mode, ios->vdd);
 
-	if (ios->power_mode == MMC_POWER_OFF)
-		mdelay(15);
-
 	if (host->ops->platform_send_init_74_clocks)
 		host->ops->platform_send_init_74_clocks(host, ios->power_mode);
 


### PR DESCRIPTION
This reverts commit 09057718f49204f07e2a79b8b8c6c5bc71ee5ddb.

#236 pulls in  [commit 67bb217](https://github.com/ni/linux/commit/67bb2175095eb1510c0282ae3ebc0079722a8cbc) that makes this commit obsolete.

[AB#3064782](https://dev.azure.com/ni/DevCentral/_workitems/edit/3064782/)