### PR TITLE
Revert "ptp: remove ptp->n_vclocks check logic in ptp_vclock_in_use()"

### DIFF
--- a/drivers/ptp/ptp_private.h
+++ b/drivers/ptp/ptp_private.h
@@ -89,7 +89,17 @@ static inline int queue_cnt(const struct timestamp_event_queue *q)
 /* Check if ptp virtual clock is in use */
 static inline bool ptp_vclock_in_use(struct ptp_clock *ptp)
 {
-	return !ptp->is_virtual_clock;
+	bool in_use = false;
+
+	if (mutex_lock_interruptible(&ptp->n_vclocks_mux))
+		return true;
+
+	if (!ptp->is_virtual_clock && ptp->n_vclocks)
+		in_use = true;
+
+	mutex_unlock(&ptp->n_vclocks_mux);
+
+	return in_use;
 }
 
 /* Check if ptp clock shall be free running */


### PR DESCRIPTION
This reverts commit 259119595227fd20f6aa29d85abe086b6fdd9eb1 as it causes clock_adjtime to fail with "ptp: physical clock is free running" in kernel log.

WI: [AB#3184608](https://dev.azure.com/ni/DevCentral/_workitems/edit/3184608/)

### Testing
- [x] `./testptp -f 0` succeeds on a cRIO-9049 (testptp from tools/testing/selftests/ptp/testptp.c). It fails without this revert.
- [x] With NI drivers installed on cRIO-9049, `lsof /dev/ptp0` shows multiple processes have opened `/dev/ptp0`.

### Note
The problematic commit is not yet present in `nilrt/master/6.12`. I've added notes in kernel upgrade work items in this cycle [AB#3125763](https://dev.azure.com/ni/DevCentral/_workitems/edit/3125763/) and [AB#3125752](https://dev.azure.com/ni/DevCentral/_workitems/edit/3125752/) to address this bug if the commit ends up in 6.12 eventually.