### PR TITLE
[ARM][ni-slsc-12001.dts] Add 802.3 compatibility string

### DIFF
--- a/arch/arm/boot/dts/ni-slsc-12001.dts
+++ b/arch/arm/boot/dts/ni-slsc-12001.dts
@@ -22,7 +22,7 @@
 		spi12 = &spiController12;
 	};
 
-	amba@0 {
+	amba: amba@0 {
 
 		gpio: gpio@e000a000 {
 			/* You can specify GPIO settings here:
@@ -521,7 +521,7 @@
 						   <&gpio 54 0>;
 
 		phy0: phy@0 {
-				compatible = "micrel,KSZ9031";
+				compatible = "micrel,KSZ9031","ethernet-phy-ieee802.3-c22";
 				device_type = "ethernet-phy";
 				reg = <0x0>;
 				/* Interrupt on GPIO1. */


### PR DESCRIPTION
As of [801a8ef54](https://github.com/ni/linux/commit/801a8ef54e8b21eb6699aaa88681259dafb1d1b5) (of: phy: Only register a phy device for phys), the OF MDIO code checks for either some 802.3 compatible strings or no compatible strings at all. This resulted in the kernel thinking that the PHYs in the NI DTs (all of which call out a compatibility property) were something other than PHYs.

other related commit: [b6e051a](https://github.com/ni/linux/commit/b6e051acdd82aaa08facc6a0c2fabb4a935311b1)

WI: [AB#3317317](https://dev.azure.com/ni/DevCentral/_workitems/edit/3317317).

Testing: Command `lsni` returns `Ethernet Adapter eth0`. Able connect to NI-MAX.