### PR TITLE
mv88e6xxx fixes for 1588 with trunked ports

### DIFF
--- a/drivers/net/dsa/mv88e6xxx/chip.c
+++ b/drivers/net/dsa/mv88e6xxx/chip.c
@@ -2515,6 +2515,64 @@ static int mv88e6xxx_port_broadcast_sync(struct mv88e6xxx_chip *chip, int port,
 				  &ctx);
 }
 
+/* The rsvd2cpu function can trap frames with destination addresses of
+ * 01:80:c2:00:00:0x and 01:80:c2:00:00:2x as management, but there are
+ * other such frames that need to be trapped to the CPU, such as destination
+ * addresses associated with 1588, that are not in those ranges.
+ */
+
+static const u8 mv88e6xxx_extra_mgmt_da[][ETH_ALEN] = {
+	/* 1588 layer 2 */
+	{ 0x01, 0x1b, 0x19, 0x00, 0x00, 0x00 },
+	/* 1588 IPv4: 224.0.1.129 */
+	{ 0x01, 0x00, 0x5e, 0x00, 0x01, 0x81 },
+	/* 1588 IPv4 P2P: 224.0.0.107 */
+	{ 0x01, 0x00, 0x5e, 0x00, 0x00, 0x6b },
+	/* 1588 IPv6: ff0e::181 */
+	{ 0x33, 0x33, 0x00, 0x00, 0x01, 0x81 },
+	/* 1588 IPv6 P2P: ff0e::6b */
+	{ 0x33, 0x33, 0x00, 0x00, 0x00, 0x6b },
+};
+
+static int mv88e6xxx_port_add_extra_mgmt(struct mv88e6xxx_chip *chip, int port,
+					 u16 vid)
+{
+	u8 state = MV88E6XXX_G1_ATU_DATA_STATE_MC_STATIC_DA_MGMT_PO;
+	int i, err;
+
+	for (i = 0; i < ARRAY_SIZE(mv88e6xxx_extra_mgmt_da); i++) {
+		err = mv88e6xxx_port_db_load_purge(chip, port,
+						   mv88e6xxx_extra_mgmt_da[i],
+						   vid, state);
+		if (err)
+			return err;
+	}
+
+	return 0;
+}
+
+static int mv88e6xxx_extra_mgmt_setup(struct mv88e6xxx_chip *chip, u16 vid)
+{
+	int port;
+	int err;
+
+	for (port = 0; port < mv88e6xxx_num_ports(chip); port++) {
+		struct dsa_port *dp = dsa_to_port(chip->ds, port);
+
+		if (dsa_is_unused_port(chip->ds, port))
+			continue;
+
+		if (!dsa_is_cpu_port(chip->ds, port))
+			continue;
+
+		err = mv88e6xxx_port_add_extra_mgmt(chip, port, vid);
+		if (err)
+			return err;
+	}
+
+	return 0;
+}
+
 static int mv88e6xxx_port_vlan_join(struct mv88e6xxx_chip *chip, int port,
 				    u16 vid, u8 member, bool warn)
 {
@@ -2550,6 +2608,10 @@ static int mv88e6xxx_port_vlan_join(struct mv88e6xxx_chip *chip, int port,
 			return err;
 
 		err = mv88e6xxx_broadcast_setup(chip, vlan.vid);
+		if (err)
+			return err;
+
+		err = mv88e6xxx_extra_mgmt_setup(chip, vlan.vid);
 		if (err)
 			return err;
 	} else if (vlan.member[port] != member) {
@@ -3937,6 +3999,10 @@ static int mv88e6xxx_setup(struct dsa_switch *ds)
 		goto unlock;
 
 	err = mv88e6xxx_broadcast_setup(chip, 0);
+	if (err)
+		goto unlock;
+
+	err = mv88e6xxx_extra_mgmt_setup(chip, 0);
 	if (err)
 		goto unlock;
 

--- a/drivers/net/dsa/mv88e6xxx/hwtstamp.c
+++ b/drivers/net/dsa/mv88e6xxx/hwtstamp.c
@@ -56,6 +56,21 @@ static int mv88e6xxx_ptp_read(struct mv88e6xxx_chip *chip, int addr,
 	return chip->info->ops->avb_ops->ptp_read(chip, addr, data, 1);
 }
 
+static int mv88e6xxx_can_embed_rxtstamp(struct mv88e6xxx_chip *chip)
+{
+	switch (chip->info->family) {
+	/* Families with "Generation 3" and later PTP IP */
+	case MV88E6XXX_FAMILY_6320:
+	case MV88E6XXX_FAMILY_6341:
+	case MV88E6XXX_FAMILY_6352:
+	case MV88E6XXX_FAMILY_6390:
+	case MV88E6XXX_FAMILY_6393:
+		return true;
+	default:
+		return false;
+	}
+}
+
 /* TX_TSTAMP_TIMEOUT: This limits the time spent polling for a TX
  * timestamp. When working properly, hardware will produce a timestamp
  * within 1ms. Software may enounter delays due to MDIO contention, so
@@ -305,22 +320,71 @@ static void mv88e6xxx_get_rxts(struct mv88e6xxx_chip *chip,
 	}
 }
 
+static void mv88e6xxx_get_rxts_from_header(struct mv88e6xxx_chip *chip,
+					   struct mv88e6xxx_port_hwtstamp *ps,
+					   struct sk_buff *skb,
+					   struct sk_buff_head *rxq)
+{
+	struct skb_shared_hwtstamps *shwt;
+	struct sk_buff_head received;
+	struct ptp_header *hdr;
+	unsigned long flags;
+	unsigned int type;
+	u64 ns;
+
+	__skb_queue_head_init(&received);
+	spin_lock_irqsave(&rxq->lock, flags);
+	skb_queue_splice_tail_init(rxq, &received);
+	spin_unlock_irqrestore(&rxq->lock, flags);
+
+	for ( ; skb; skb = __skb_dequeue(&received)) {
+		type = SKB_PTP_TYPE(skb);
+		hdr = ptp_parse_header(skb, type);
+		if (hdr) {
+			/* The hardware was configured to embed the timestamp
+			 * into the reserved field in the incoming packet.
+			 */
+			ns = be32_to_cpu(hdr->reserved2);
+
+			/* The hardware, however, did not update any applicable
+			 * checksums (such as for UDP) so reset the reserved
+			 * field to 0 so that it matches the state from when
+			 * the checksum was generated.
+			 */
+			hdr->reserved2 = 0;
+
+			mv88e6xxx_reg_lock(chip);
+			ns = timecounter_cyc2time(&chip->tstamp_tc, ns);
+			mv88e6xxx_reg_unlock(chip);
+			shwt = skb_hwtstamps(skb);
+			memset(shwt, 0, sizeof(*shwt));
+			shwt->hwtstamp = ns_to_ktime(ns);
+		}
+		netif_rx(skb);
+	}
+}
+
 static void mv88e6xxx_rxtstamp_work(struct mv88e6xxx_chip *chip,
 				    struct mv88e6xxx_port_hwtstamp *ps)
 {
 	const struct mv88e6xxx_ptp_ops *ptp_ops = chip->info->ops->ptp_ops;
 	struct sk_buff *skb;
 
-	skb = skb_dequeue(&ps->rx_queue);
+	if (mv88e6xxx_can_embed_rxtstamp(chip)) {
+		skb = skb_dequeue(&ps->rx_queue);
+		if (skb)
+			mv88e6xxx_get_rxts_from_header(chip, ps, skb, &ps->rx_queue);
+	} else {
+		skb = skb_dequeue(&ps->rx_queue);
+		if (skb)
+			mv88e6xxx_get_rxts(chip, ps, skb, ptp_ops->arr0_sts_reg,
+					   &ps->rx_queue);
 
-	if (skb)
-		mv88e6xxx_get_rxts(chip, ps, skb, ptp_ops->arr0_sts_reg,
-				   &ps->rx_queue);
-
-	skb = skb_dequeue(&ps->rx_queue2);
-	if (skb)
-		mv88e6xxx_get_rxts(chip, ps, skb, ptp_ops->arr1_sts_reg,
-				   &ps->rx_queue2);
+		skb = skb_dequeue(&ps->rx_queue2);
+		if (skb)
+			mv88e6xxx_get_rxts(chip, ps, skb, ptp_ops->arr1_sts_reg,
+					   &ps->rx_queue2);
+	}
 }
 
 static int is_pdelay_resp(const struct ptp_header *hdr)
@@ -347,7 +411,7 @@ bool mv88e6xxx_port_rxtstamp(struct dsa_switch *ds, int port,
 
 	SKB_PTP_TYPE(skb) = type;
 
-	if (is_pdelay_resp(hdr))
+	if (is_pdelay_resp(hdr) && !mv88e6xxx_can_embed_rxtstamp(chip))
 		skb_queue_tail(&ps->rx_queue2, skb);
 	else
 		skb_queue_tail(&ps->rx_queue, skb);
@@ -533,6 +597,20 @@ int mv88e6352_hwtstamp_port_disable(struct mv88e6xxx_chip *chip, int port)
 
 int mv88e6352_hwtstamp_port_enable(struct mv88e6xxx_chip *chip, int port)
 {
+	int err;
+
+	if (mv88e6xxx_can_embed_rxtstamp(chip)) {
+		/* Some versions of the Marvell PTP IP can be configured to
+		 * place timestamps into the 32-bit "reserved" field; this
+		 * avoids the possibility of timestamps being overwritten
+		 * because software hasn't read them in time.
+		 */
+		err = mv88e6xxx_port_ptp_write(chip, port, MV88E6XXX_PORT_PTP_CFG2,
+					       MV88E6XXX_PORT_PTP_CFG2_EMBED_ARRIVAL);
+		if (err)
+			return err;
+	}
+
 	return mv88e6xxx_port_ptp_write(chip, port, MV88E6XXX_PORT_PTP_CFG0,
 					MV88E6XXX_PORT_PTP_CFG0_DISABLE_TSPEC_MATCH);
 }


### PR DESCRIPTION
Two patches here, technically they're separate things but related.

- embed rx timestamps into packets
    - our 4.1 pre-upstream implementation of mv88e6xxx hardware timestamping used a feature on the switch to embed the hardware's 32-bit timestamp counter into the "reserved2" field of an incoming PTP packet, but the implementation that landed upstream uses an older method of reading out the timestamp counter over SMI for the sake of older generations of hardware. I'm seeing a large number of timestamp overruns with this approach though in our test networks, though, especially in instances where both layer 2 (802.1AS) and layer 4 (1588 UDP) masters are running.
    - fixes [AB#3396801](https://dev.azure.com/ni/DevCentral/_workitems/edit/3396801/)
    -  [Upstream mailing list traffic suggests that there are PTP testers that will also trigger this](https://lore.kernel.org/netdev/DD8PM8593EAM.1FQU37SU51BLJ@gmail.com/); but also there's a big outstanding patchset that refactors Marvell timestamping to share code amongst the PHYs and switch products (see that whole thread), so this may need to be reworked with that patchset in mind to bring it upstream.
    - an upstream quibble I would expect is the use of a switch statement for checking families rather than extending `struct mv88e6xxx_ptp_ops` to indicate whether the switch chip has this capability.
- add 1588-related addresses to ATU as management frames
    - when ports are trunked due to being placed in a link-aggregated bond, 1588 packets weren't getting delivered to the port interfaces anymore; this was because the packets were getting a DSA tag indicating that they're part of a trunk, and [the DSA infrastructure applies them to the bond interface in that case](https://github.com/ni/linux/blob/9f2f3965b02c845995c14b390e549fc7dc0bfc5d/net/dsa/tag_dsa.c#L263). The solution is to program the ATU to indicate that packets with 1588-related destination addresses are to be treated as management frames and trapped to the CPU, which gives them the same behavior that the "rsvd2cpu" function already applies for `01:80:c2:00:00:0x`. We do this for every VLAN, regardless of whether or not hardware timestamping is enabled.
    - required for [AB#3432087](https://dev.azure.com/ni/DevCentral/_workitems/edit/3432087/)