### PR TITLE
ni-bluefin: enable mv88e6xxx PHY interrupts

### DIFF
--- a/arch/arm/boot/dts/xilinx/ni-bluefin.dts
+++ b/arch/arm/boot/dts/xilinx/ni-bluefin.dts
@@ -1,4 +1,5 @@
 /dts-v1/;
+#include <dt-bindings/interrupt-controller/irq.h>
 /include/ "ni-zynq.dtsi"
 
 /* NIDEVCODE 78C7 */
@@ -86,6 +87,10 @@
 		compatible = "marvell,mv88e6085";
 		reg = <0x0>;
 		status = "okay";
+		interrupt-parent = <&intc>;
+		interrupts = <45 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
 
 		ports {
 			#address-cells = <1>;
@@ -122,14 +127,6 @@
 
 			swphy2: ethernet-phy@12 {
 				reg = <0x12>;
-			};
-
-			swphy3: ethernet-phy@13 {
-				reg = <0x13>;
-			};
-
-			swphy4: ethernet-phy@14 {
-				reg = <0x14>;
 			};
 		};
 	};


### PR DESCRIPTION
The mv88e6xxx driver gained support for PHY interrupt handling in newer kernels (6.12), whereas older kernels (e.g. 4.1) only supported polling over the MDIO bus.

On ni-bluefin, the PHY interrupt lines have always been physically connected on the board but were not used previously due to the lack of driver support.

Enabling PHY interrupts in the device tree allows the driver to rely on interrupt-driven link and status updates instead of frequent MDIO polling. This significantly reduces MDIO bus traffic and contention.

Reducing MDIO contention is required to free up bus bandwidth, allowing the system to sustain higher sampling rates without MDIO-related interference.

Tested on my local cDAQ9189, we are able to sample up to 4MS/s/ch on 9775 now which we were not able to do previously.