### PR TITLE
dts: Add device tree for fielddaq devices

### DIFF
--- a/arch/arm/boot/dts/xilinx/ni-fielddaq.dts
+++ b/arch/arm/boot/dts/xilinx/ni-fielddaq.dts
@@ -1,0 +1,232 @@
+/dts-v1/;
+#include <dt-bindings/interrupt-controller/irq.h>
+/include/ "ni-zynq.dtsi"
+/* NIDEVCODE 79FF */
+/* NIDEVCODE 7943 */
+/* NIDEVCODE 7941 */
+
+/ {
+	model = "NI FieldDAQ";
+	compatible = "ni,zynq", "xlnx,zynq-7000";
+
+	/*
+	 * This 100MHz reference clock is actually the output of a Si514;
+	 * However, we do not declare it in the device tree because it is
+	 * steered in usermode, and therefore we don't want a kernel driver
+	 * to attach to it.
+	 */
+	ref100: oscillator {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <100000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* "LED_USER_RED" is on GPIO1 */
+		status {
+			label = "nilrt:status:red";
+			gpios = <&gpio0 1 0>;
+			default-state = "on";
+		};
+
+		/* "LED_USER_GREEN" is on GPIO15 */
+		active {
+			label = "nilrt:active:green";
+			gpios = <&gpio0 15 0>;
+			default-state = "on";
+		};
+
+		/* "ZYNQ_LED0_P1" is on GPIO47 */
+		port1 {
+			label = "nilrt:port1:green";
+			gpios = <&gpio0 47 0>;
+			linux,default-trigger = "dsa-0:00:01:link";
+		};
+
+		/* "ZYNQ_LED0_P2" is on GPIO46 */
+		port2 {
+			label = "nilrt:port2:green";
+			gpios = <&gpio0 46 0>;
+			linux,default-trigger = "dsa-0:00:02:link";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* Reset switch is on GPIO48 */
+		reset_sw@0 {
+			label = "reset_sw";
+			gpios = <&gpio0 48 1 /* GPIO_ACTIVE_LOW */>;
+			linux,code = <408>; /* KEY_RESTART */
+			gpio-key,wakeup;
+		};
+	};
+
+	gpio_restart {
+		compatible = "gpio-restart";
+
+		/* ~PS_FORCE_RESET is on GPIO44 */
+		gpios = <&gpio0 44 1 /* GPIO_ACTIVE_LOW */>;
+		priority = <200>;
+	};
+
+    si5351c: clock-generator@60 {
+				compatible = "silabs,si5351c";
+				reg = <0x60>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				#clock-cells = <1>;
+
+				clocks = <&ref100>;
+				clock-names = "clkin";
+
+				silabs,pll-source = <0 1>, <1 0>;
+				silabs,pll-frequency = <0 737280000>;
+
+				umber-btsi0 {
+					reg = <0>;
+					silabs,drive-strength = <8>;
+					silabs,multisynth-source = <0>;
+					silabs,clock-source = <0>;
+					silabs,disable-state = <0>;
+					clock-frequency = <12800000>;
+				};
+
+				umber-sysclk {
+					reg = <1>;
+					silabs,drive-strength = <8>;
+					silabs,multisynth-source = <0>;
+					silabs,clock-source = <0>;
+					silabs,disable-state = <0>;
+					clock-frequency = <80000000>;
+				};
+
+				umber-btsi1 {
+					reg = <2>;
+					silabs,drive-strength = <8>;
+					silabs,multisynth-source = <0>;
+					silabs,clock-source = <0>;
+					silabs,disable-state = <0>;
+					clock-frequency = <13107200>;
+				};
+
+				umber-btsi3 {
+					reg = <4>;
+					silabs,drive-strength = <8>;
+					silabs,multisynth-source = <0>;
+					silabs,clock-source = <0>;
+					silabs,disable-state = <0>;
+					clock-frequency = <10240000>;
+				};
+
+				umber-btsi4 {
+					reg = <7>;
+					silabs,drive-strength = <8>;
+					silabs,multisynth-source = <0>;
+					silabs,clock-source = <0>;
+					silabs,disable-state = <0>;
+					clock-frequency = <12288000>;
+				};
+			};
+};
+
+&i2c0 {
+	/* Override ni-zynq.dtsi; we do not have a CPLD at 0x40. */
+	nicpld@40 {
+		status = "disabled";
+	};
+
+	tmp451@4C {
+		compatible = "ti,tmp451";
+		reg = <0x4C>;
+		vcc-supply = <&regulator_vccpint>;
+	};
+};
+
+&gem0 {
+	status = "okay";
+	#address-cells = <0x1>;
+	#size-cells = <0x0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+		reg = <0>;
+	};
+
+	mdio0: mdio {
+		status = "okay";
+	};
+};
+
+&mdio0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	switch: switch@0 {
+		compatible = "marvell,mv88e6085";
+		reg = <0x0>;
+		status = "okay";
+		interrupt-parent = <&intc>;
+		interrupts = <45 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "cpu";
+				phy-mode = "rgmii-id";
+				ethernet = <&gem0>;
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "sw0";
+				phy-handle = <&swphy1>;
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "sw1";
+				phy-handle = <&swphy2>;
+			};
+		};
+
+		mdio {
+			swphy1: ethernet-phy@11 {
+				reg = <0x11>;
+			};
+
+			swphy2: ethernet-phy@12 {
+				reg = <0x12>;
+			};
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	dr_mode = "host";
+};
+
+&watchdog0 {
+	status = "okay";
+	reset-on-timeout;
+};


### PR DESCRIPTION
Device tree for FieldDAQ devices are for FD-11613, FD-11614 and FD-11637. There were other FieldDAQs that existed in bluefin/master/4.1 branch but those are discontinued now.
The changes here are to update the model name, NIDEVCODE, addition of ref100 and si5351c chip, and some LED changes. 
Otherwise, the rest of the device tree remains the same as Bluefin.

Testing:
When built together with these changes https://github.com/ni/meta-expio/pull/64, we were able to get ni-fielddaq.dtb generated.
<img width="407" height="536" alt="image" src="https://github.com/user-attachments/assets/1a66e22a-5203-4040-a1d7-ed8054af2b26" />
