### PR TITLE
[4.14] nati_zynq_defconfig: Enable CORE_DUMP_DEFAULT_ELF_HEADERS

### DIFF
--- a/arch/arm/configs/nati_zynq_defconfig
+++ b/arch/arm/configs/nati_zynq_defconfig
@@ -43,7 +43,6 @@ CONFIG_ZBOOT_ROM_BSS=0x0
 CONFIG_CMDLINE="console=ttyPS0,115200n8 root=/dev/ram rw initrd=0x00800000,16M earlyprintk mtdparts=physmap-flash.0:512K(nor-fsbl),512K(nor-u-boot),5M(nor-linux),9M(nor-user),1M(nor-scratch),-(nor-rootfs)"
 CONFIG_VFP=y
 CONFIG_NEON=y
-# CONFIG_CORE_DUMP_DEFAULT_ELF_HEADERS is not set
 # CONFIG_SUSPEND is not set
 CONFIG_NET=y
 CONFIG_PACKET=y


### PR DESCRIPTION
Enable CORE_DUMP_DEFAULT_ELF_HEADERS so core files contain build-id which is useful during debugging.

Ported from commit 28f912c79a7f75dd70e92068f7b57198e67108b7.

### Testing
- [x] Built `linux-nilrt-arm-safemode`.
- [x] Booted this safemode on a cRIO-9068 and verified core dump contains build-ids.