### PR TITLE
ARM: dts: ni-zynq: Fix USB PHY references

### DIFF
--- a/arch/arm/boot/dts/xilinx/ni-zynq.dtsi
+++ b/arch/arm/boot/dts/xilinx/ni-zynq.dtsi
@@ -138,11 +138,11 @@
 };
 
 &usb0 {
-	usb-phy = <&usb_phy0>;
+	phys = <&usb_phy0>;
 };
 
 &usb1 {
-	usb-phy = <&usb_phy1>;
+	phys = <&usb_phy1>;
 };
 
 &smcc {


### PR DESCRIPTION
Update usb dt nodes so that USB works on ARM devices with 6.18 kernel.

### Testing
- [x] Built safemode - `bitbake packagefeed-ni-core && bitbake package-index && bitbake linux-nilrt-arm-safemode`
- [x] Installed safemode on a myRIO-1900 and verified USB gadget works and USB to ethernet adapter works.